### PR TITLE
Disable symbolproc rubocop warnings

### DIFF
--- a/features/step_definitions/compliance_steps.rb
+++ b/features/step_definitions/compliance_steps.rb
@@ -1,4 +1,4 @@
-When(/^(Joe|Patricia) views the compliance stats$/) do |actor|
+When(/^(Joe|Patricia) views the compliance stats$/) do |actor| # rubocop:disable Style/SymbolProc
   actor.attempts_to_view_minimum_compliance_requirements_stats
 end
 

--- a/features/step_definitions/download_steps.rb
+++ b/features/step_definitions/download_steps.rb
@@ -1,4 +1,4 @@
-When(/^(Joe|Patricia) downloads all statements$/) do |actor|
+When(/^(Joe|Patricia) downloads all statements$/) do |actor| # rubocop:disable Style/SymbolProc
   actor.attempts_to_download_all_statements
 end
 

--- a/features/step_definitions/security_steps.rb
+++ b/features/step_definitions/security_steps.rb
@@ -11,7 +11,7 @@ When(/^(Joe|Patricia|Vicky) logs in$/) do |actor|
   actor.attempts_to_log_in
 end
 
-When(/^(Joe|Patricia|Vicky) visits the administrator dashboard$/) do |actor|
+When(/^(Joe|Patricia|Vicky) visits the administrator dashboard$/) do |actor| # rubocop:disable Style/SymbolProc
   actor.attempts_to_visit_admin_dashboard
 end
 


### PR DESCRIPTION
Silence warnings like this one:

```
features/step_definitions/security_steps.rb:14:67: C: Pass &:attempts_to_visit_admin_dashboard as an argument to When instead of a block.
When(/^(Joe|Patricia|Vicky) visits the administrator dashboard$/) do |actor| ...
                                                                  ^^^^^^^^^^
```

Interested to know your thoughts on this @aslakhellesoy, as it relates to cucumber and the screenplay pattern:

1. Cucumber doesn't accept symbol procs as step def block arguments... is that a bug? should I fix it?

2. These step definitions could be generated from the list of actor abilities! That would mean changing the language in the scenarios to e.g. "Joe *attemtps to visit* the administrator dashboard". I'm wondering why we use the language of "attempts to" in the screenplay, but not in the scenarios....