### PR TITLE
Rename newest to latest, cache for easy/fast queries

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,7 +3,7 @@ module Admin
     def show
       @total = 0
       @stats = { approved_by_board: 0, link_on_front_page: 0, signed_by_director: 0, fully_compliant: 0 }
-      Statement.newest.to_a.map do |s|
+      Statement.latest.to_a.map do |s|
         @stats[:approved_by_board] += 1 if s.approved_by_board == 'Yes'
         @stats[:link_on_front_page] += 1 if s.link_on_front_page?
         @stats[:signed_by_director] += 1 if s.signed_by_director?

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -54,7 +54,7 @@ class CompaniesController < ApplicationController
   def after_save_path_for_company(company)
     if company.statements.any?
       if admin?
-        company_statement_path(company, company.newest_statement)
+        company_statement_path(company, company.latest_statement)
       else
         thanks_path
       end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -7,7 +7,15 @@ class Company < ApplicationRecord
 
   accepts_nested_attributes_for :statements, reject_if: :all_blank, allow_destroy: true
 
-  def newest_statement
-    statements.newest.first
+  def latest_statement
+    statements.latest.first
+  end
+
+  def country_name
+    try(:country).try(:name) || 'Country unknown'
+  end
+
+  def sector_name
+    try(:sector).try(:name) || 'Sector unknown'
   end
 end

--- a/app/models/statement_search.rb
+++ b/app/models/statement_search.rb
@@ -5,16 +5,16 @@ class StatementSearch
   end
 
   def statements
-    @statements = Statement.newest.includes(:verified_by, company: %i[sector country])
+    @statements = Statement.includes(:verified_by, company: %i[sector country])
     filter_by_published
     filter_by_company
-    @statements
+    @statements.order('companies.name')
   end
 
   private
 
   def filter_by_published
-    @statements = @statements.published unless @admin
+    @statements = @admin ? @statements.latest : @statements.latest_published
   end
 
   def filter_by_company

--- a/db/migrate/20170610060421_add_latest_and_latest_published_to_statements.rb
+++ b/db/migrate/20170610060421_add_latest_and_latest_published_to_statements.rb
@@ -1,0 +1,8 @@
+class AddLatestAndLatestPublishedToStatements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :statements, :latest, :boolean, default: false
+    add_column :statements, :latest_published, :boolean, default: false
+    add_index :statements, :latest, where: :latest
+    add_index :statements, :latest_published, where: :latest_published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170602144706) do
+ActiveRecord::Schema.define(version: 20170610060421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,21 +62,25 @@ ActiveRecord::Schema.define(version: 20170602144706) do
   end
 
   create_table "statements", force: :cascade do |t|
-    t.integer  "company_id",         null: false
-    t.string   "url",                null: false
-    t.date     "date_seen",          null: false
+    t.integer  "company_id",                         null: false
+    t.string   "url",                                null: false
+    t.date     "date_seen",                          null: false
     t.string   "approved_by_board"
     t.string   "approved_by"
     t.boolean  "signed_by_director"
     t.string   "signed_by"
     t.boolean  "link_on_front_page"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.boolean  "broken_url"
     t.integer  "verified_by_id"
     t.boolean  "published"
     t.string   "contributor_email"
+    t.boolean  "latest",             default: false
+    t.boolean  "latest_published",   default: false
     t.index ["company_id"], name: "index_statements_on_company_id", using: :btree
+    t.index ["latest"], name: "index_statements_on_latest", where: "latest", using: :btree
+    t.index ["latest_published"], name: "index_statements_on_latest_published", where: "latest_published", using: :btree
     t.index ["published"], name: "index_statements_on_published", using: :btree
     t.index ["verified_by_id"], name: "index_statements_on_verified_by_id", using: :btree
   end

--- a/features/publish_statement.feature
+++ b/features/publish_statement.feature
@@ -13,8 +13,8 @@ Feature: Publish statement
       | approved_by_board  | No                                         |
       | link_on_front_page | No                                         |
       | published          | Yes                                        |
-    Then Patricia should see that the newest statement for "Cucumber Ltd" was verified by herself
-    And Patricia should see that the newest statement for "Cucumber Ltd" was contributed by herself
+    Then Patricia should see that the latest statement for "Cucumber Ltd" was verified by herself
+    And Patricia should see that the latest statement for "Cucumber Ltd" was contributed by herself
 
   Scenario: Admin submits a draft statement without publishing it
     Given Patricia is logged in
@@ -26,9 +26,9 @@ Feature: Publish statement
       | approved_by_board  | No                                         |
       | link_on_front_page | No                                         |
       | published          | No                                         |
-    Then Patricia should see that the newest statement for "Cucumber Ltd" is not published
-    And Patricia should see that the newest statement for "Cucumber Ltd" was not verified
-    And Patricia should see that the newest statement for "Cucumber Ltd" was contributed by herself
+    Then Patricia should see that the latest statement for "Cucumber Ltd" is not published
+    And Patricia should see that the latest statement for "Cucumber Ltd" was not verified
+    And Patricia should see that the latest statement for "Cucumber Ltd" was contributed by herself
 
   Scenario: Admin publishes a statement submitted by someone else
     When Vicky submits the following statement:
@@ -36,9 +36,9 @@ Feature: Publish statement
       | url                | https://cucumber.io/anti-slavery-statement |
       | contributor_email  | vicky@host.com                             |
     Given Patricia is logged in
-    Then Patricia should see that the newest statement for "Cucumber Ltd" is not published
-    And Patricia should see that the newest statement for "Cucumber Ltd" was not verified
-    And Patricia should see that the newest statement for "Cucumber Ltd" was contributed by vicky@host.com
+    Then Patricia should see that the latest statement for "Cucumber Ltd" is not published
+    And Patricia should see that the latest statement for "Cucumber Ltd" was not verified
+    And Patricia should see that the latest statement for "Cucumber Ltd" was contributed by vicky@host.com
 
   Scenario: Admin deletes a statement
     When Vicky submits the following statement:

--- a/features/search_statements.feature
+++ b/features/search_statements.feature
@@ -10,7 +10,7 @@ Feature: Search statements
   Scenario: Search by company name
     Given Joe is logged in
     When Joe searches for "cucumber"
-    Then Joe should only see "Cucumber Ltd, Cucumber Inc" in the search results
+    Then Joe should only see "Cucumber Inc, Cucumber Ltd" in the search results
 
   Scenario: Filter by sector
     When Joe selects sector "Agriculture"

--- a/features/step_definitions/snapshot_steps.rb
+++ b/features/step_definitions/snapshot_steps.rb
@@ -34,7 +34,7 @@ end
 module AttemptsToViewTheLatestSnapshot
   def attempts_to_view_the_latest_snapshot(company_name:)
     company = Company.find_by(name: company_name)
-    visit(company_statement_path(company, company.newest_statement))
+    visit(company_statement_path(company, company.latest_statement))
     within '[data-content="latest_shapshot"]' do
       click_on 'Download'
     end

--- a/features/step_definitions/statement_steps.rb
+++ b/features/step_definitions/statement_steps.rb
@@ -69,25 +69,25 @@ Then(/(Joe|Patricia) should only see "([^"]*)" in the search results$/) do |acto
   expect(actor.visible_listed_statements_from_search.map(&:company_name)).to eq(company_names)
 end
 
-Then(/^(Joe|Patricia) should see that the newest statement for "([^"]*)" was verified by herself$/) do |actor, company_name|
-  expect(actor.visible_newest_statement_by_company(company_name: company_name).verified_by).to eq(actor.name)
+Then(/^(Joe|Patricia) should see that the latest statement for "([^"]*)" was verified by herself$/) do |actor, company_name|
+  expect(actor.visible_latest_statement_by_company(company_name: company_name).verified_by).to eq(actor.name)
 end
 
-Then(/^(Joe|Patricia) should see that the newest statement for "([^"]*)" was contributed by (.*)$/) do |actor, company_name, contributor_email|
+Then(/^(Joe|Patricia) should see that the latest statement for "([^"]*)" was contributed by (.*)$/) do |actor, company_name, contributor_email|
   contributor_email = User.find_by!(first_name: actor.name).email if contributor_email == 'herself'
-  expect(actor.visible_newest_statement_by_company(company_name: company_name).contributor_email).to eq(contributor_email)
+  expect(actor.visible_latest_statement_by_company(company_name: company_name).contributor_email).to eq(contributor_email)
 end
 
-Then(/^(Joe|Patricia) should see that the newest statement for "([^"]*)" is not published$/) do |actor, company_name|
-  expect(actor.visible_newest_statement_by_company(company_name: company_name).published).to eq('Draft')
+Then(/^(Joe|Patricia) should see that the latest statement for "([^"]*)" is not published$/) do |actor, company_name|
+  expect(actor.visible_latest_statement_by_company(company_name: company_name).published).to eq('Draft')
 end
 
-Then(/^(Joe|Patricia) should see that the newest statement for "([^"]*)" was not verified$/) do |actor, company_name|
-  expect(actor.visible_newest_statement_by_company(company_name: company_name).verified_by).to eq(nil)
+Then(/^(Joe|Patricia) should see that the latest statement for "([^"]*)" was not verified$/) do |actor, company_name|
+  expect(actor.visible_latest_statement_by_company(company_name: company_name).verified_by).to eq(nil)
 end
 
 Then(/^(Joe|Patricia) should see that no statement for "([^"]*)" exists$/) do |actor, company_name|
-  expect(actor.visible_newest_statement_by_company(company_name: company_name)).to be_nil
+  expect(actor.visible_latest_statement_by_company(company_name: company_name)).to be_nil
 end
 
 Then(/^(Joe|Patricia) should see that the statement was invalid and not saved$/) do |actor|
@@ -140,7 +140,7 @@ end
 module AttemptsToUpdateStatement
   def attempts_to_update_statement(company_name:, new_values:)
     company = Company.find_by!(name: company_name)
-    visit company_statement_path(company, company.newest_statement)
+    visit company_statement_path(company, company.latest_statement)
     click_link 'Edit'
     fill_in('Company name', with: new_values.fetch('company_name'))
     click_button 'Submit'
@@ -159,16 +159,16 @@ module AttemptsToDeleteLatestStatementByCompany
 
   def attempts_to_delete_latest_statement_by_company(company_name:)
     company = Company.find_by(name: company_name)
-    visit company_statement_path(company, company.newest_statement)
+    visit company_statement_path(company, company.latest_statement)
     click_on 'Delete'
   end
 end
 
-module SeesTheNewestStatement
-  def visible_newest_statement_by_company(company_name:)
+module SeesTheLatestStatement
+  def visible_latest_statement_by_company(company_name:)
     company = Company.find_by(name: company_name)
-    return nil if company.newest_statement.nil?
-    visit company_statement_path(company, company.newest_statement)
+    return nil if company.latest_statement.nil?
+    visit company_statement_path(company, company.latest_statement)
 
     dom_struct(:statement, :verified_by, :contributor_email, :published)
   end
@@ -206,7 +206,7 @@ class Visitor
   include AttemptsToUpdateStatement
   include AttemptsToFindAllStatementsByCompany
   include AttemptsToDeleteLatestStatementByCompany
-  include SeesTheNewestStatement
+  include SeesTheLatestStatement
   include SeesTheListedStatements
   include SeesValidationErrors
 end

--- a/spec/models/statement_search_spec.rb
+++ b/spec/models/statement_search_spec.rb
@@ -1,112 +1,111 @@
 require 'rails_helper'
 
 RSpec.describe Statement, type: :model do
-  before do
-    @sw = Sector.create! name: 'Software'
-    @ag = Sector.create! name: 'Agriculture'
-    @gb = Country.create! code: 'GB', name: 'United Kingdom'
-    @no = Country.create! code: 'NO', name: 'Norway'
-    @company_cucumber = Company.create! name: 'Cucumber Ltd', country_id: @gb.id, sector_id: @sw.id
-    @company_potato = Company.create! name: 'Potato Ltd', country_id: @gb.id, sector_id: @ag.id
-    @c2016 = @company_cucumber.statements.create!(url: 'http://cucumber.io/2016',
-                                                  approved_by: 'Aslak',
-                                                  approved_by_board: 'Yes',
-                                                  signed_by_director: false,
-                                                  link_on_front_page: true,
-                                                  date_seen: Date.parse('21 May 2016'),
-                                                  published: true,
-                                                  contributor_email: 'someone@somewhere.com')
-    @p2016 = @company_potato.statements.create!(url: 'http://potato.io/2016',
-                                                approved_by: 'Aslak',
-                                                approved_by_board: 'Yes',
-                                                signed_by_director: 'No',
-                                                link_on_front_page: true,
-                                                date_seen: Date.parse('20 May 2016'),
-                                                published: false,
-                                                contributor_email: 'someone@somewhere.com')
-    @c2017 = @company_cucumber.statements.create!(url: 'http://cucumber.io/2017',
-                                                  approved_by: 'Aslak',
-                                                  approved_by_board: 'Yes',
-                                                  signed_by_director: false,
-                                                  link_on_front_page: true,
-                                                  date_seen: Date.parse('22 June 2017'),
-                                                  published: false,
-                                                  contributor_email: 'someone@somewhere.com')
+  let :software do
+    Sector.create! name: 'Software'
   end
 
-  it 'can be searched by company name' do
-    search = Statement.search(admin: false, criteria: { company_name: 'cucumber' })
-    expect(search.statements).to eq([@c2016])
+  let :agriculture do
+    Sector.create! name: 'Agriculture'
   end
 
-  it 'lists most recent statements' do
-    statements = Statement.includes(:company).all.newest
-    expect(statements).to eq([@c2017, @p2016])
+  let :gb do
+    Country.create! code: 'GB', name: 'United Kingdom'
   end
 
-  it 'lists most recent published statements' do
-    statements = Statement.includes(:company).all.newest.published
-    expect(statements).to eq([@c2016])
+  let :no do
+    Country.create! code: 'NO', name: 'Norway'
   end
 
-  it 'is searchable by company name and published status' do
-    statements = Statement.published.includes(:company)
-                          .joins(:company).where('LOWER(name) LIKE LOWER(?)', '%ucumber%')
-    expect(statements).to eq([@c2016])
+  let :cucumber do
+    Company.create! name: 'Cucumber Ltd', country: gb, sector: software
   end
 
-  it 'is filterable by company sector' do
-    statements = Statement.includes(:company)
-                          .joins(:company).where(companies: { sector_id: @sw.id })
-    expect(statements).to match_array([@c2016, @c2017])
+  let :potato do
+    Company.create! name: 'Potato Ltd', country: no, sector: agriculture
   end
 
-  it 'is filterable by company sector and published status' do
-    statements = Statement.published.includes(:company)
-                          .joins(:company).where(companies: { sector_id: @sw.id })
-    expect(statements).to eq([@c2016])
+  let! :cucumber_2016 do
+    cucumber.statements.create!(
+      url: 'http://cucumber.io/2016',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: false,
+      link_on_front_page: true,
+      date_seen: Date.parse('21 May 2016'),
+      published: true,
+      contributor_email: 'someone@somewhere.com'
+    )
   end
 
-  it 'is filterable by company sector and published status, listing only newest' do
-    statements = Statement.newest.published.includes(:company)
-                          .joins(:company).where(companies: { sector_id: @sw.id })
-    expect(statements).to eq([@c2016])
+  let! :cucumber_2017 do
+    cucumber.statements.create!(
+      url: 'http://cucumber.io/2017',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: false,
+      link_on_front_page: true,
+      date_seen: Date.parse('22 June 2017'),
+      published: false,
+      contributor_email: 'someone@somewhere.com'
+    )
   end
 
-  it 'is filterable by country' do
-    statements = Statement.newest.published.includes(:company)
-                          .joins(:company).where(companies: { country_id: @gb.id })
-    expect(statements).to eq([@c2016])
+  let! :potato_2016 do
+    potato.statements.create!(
+      url: 'http://potato.io/2016',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: 'No',
+      link_on_front_page: true,
+      date_seen: Date.parse('20 May 2016'),
+      published: true,
+      contributor_email: 'someone@somewhere.com'
+    )
   end
 
-  it 'is filterable by country and sector' do
-    statements = Statement.newest.published.includes(:company)
-                          .joins(:company).where(companies: {
-                                                   country_id: @gb.id,
-                                                   sector_id: @sw.id
-                                                 })
-    expect(statements).to eq([@c2016])
+  let! :potato_2017 do
+    potato.statements.create!(
+      url: 'http://potato.io/2017',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: 'No',
+      link_on_front_page: true,
+      date_seen: Date.parse('20 May 2017'),
+      published: false,
+      contributor_email: 'someone@somewhere.com'
+    )
   end
 
-  it 'is filterable by company name, country and sector' do
-    statements = Statement.newest.published.includes(:company)
-                          .joins(:company)
-                          .where('LOWER(name) LIKE LOWER(?)', '%ucumber%')
-                          .where(companies: {
-                                   country_id: @gb.id,
-                                   sector_id: @sw.id
-                                 })
-    expect(statements).to eq([@c2016])
+  context 'when the searcher is an admin' do
+    it 'finds latest statements ordered by company name' do
+      search = Statement.search(admin: true, criteria: {})
+      expect(search.statements).to eq([cucumber_2017, potato_2017])
+    end
   end
 
-  it 'is filterable by company name, country and sector (no hits)' do
-    statements = Statement.newest.published.includes(:company)
-                          .joins(:company)
-                          .where('LOWER(name) LIKE LOWER(?)', '%WAT%')
-                          .where(companies: {
-                                   country_id: @gb.id,
-                                   sector_id: @sw.id
-                                 })
-    expect(statements).to eq([])
+  context 'when the searcher is not an admin' do
+    it 'finds latest published statements ordered by company name' do
+      search = Statement.search(admin: false, criteria: {})
+      expect(search.statements).to eq([cucumber_2016, potato_2016])
+    end
+  end
+
+  it 'filters statements by company name' do
+    expect(Statement.search(admin: false, criteria: { company_name: 'cucum' }).statements).to eq([cucumber_2016])
+  end
+
+  it 'filters statements by countries' do
+    expect(Statement.search(admin: true, criteria: { countries: [no.id] }).statements).to eq([potato_2017])
+    expect(Statement.search(admin: false, criteria: { countries: [gb.id, no.id] }).statements).to eq(
+      [cucumber_2016, potato_2016]
+    )
+  end
+
+  it 'filters statements by company sectors' do
+    expect(Statement.search(admin: true, criteria: { sectors: [agriculture.id] }).statements).to eq([potato_2017])
+    expect(Statement.search(admin: false, criteria: { sectors: [agriculture.id, software.id] }).statements).to eq(
+      [cucumber_2016, potato_2016]
+    )
   end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -73,8 +73,7 @@ RSpec.describe Statement, type: :model do
                                   date_seen: Date.parse('2017-03-22'),
                                   published: true)
 
-      statements = Statement.newest.published.includes(company: %i[sector country])
-      csv = Statement.to_csv(statements, false)
+      csv = Statement.to_csv(@company.statements.includes(company: %i[sector country]), false)
 
       expect(csv).to eq(<<~CSV
         Company,URL,Sector,HQ,Date Added
@@ -103,8 +102,7 @@ CSV
                                   date_seen: Date.parse('2017-03-22'),
                                   published: true)
 
-      statements = Statement.newest.published.includes(company: %i[sector country])
-      csv = Statement.to_csv(statements, true)
+      csv = Statement.to_csv(@company.statements.includes(company: %i[sector country]), true)
 
       expect(csv).to eq(<<~CSV
         Company,URL,Sector,HQ,Date Added,Approved by Board,Approved by,Signed by Director,Signed by,Link on Front Page,Published,Verified by,Contributed by,Broken URL


### PR DESCRIPTION
Statement.newest had a couple of issues:

1. "newest" is a slightly weird word, "latest" tends to be preferred for "most recent of its kind"

2. The scope in statement used `DISTINCT ON (statements.company_id) statements.*` - which made it difficult to use in the ways we would normally use a scope. For example, `Statement.newest.count` was broken.

3. It probably wouldn't scale that well because it had to do a relatively complex query for every statement search.

This PR introduces two booleans on `Statement` which are updated when statements are saved: `latest` is set to true when the statement is the latest by that company, ignoring published status. `latest_published` is the same but only considers published statements. Since these are indexed, they should lead to faster searches and less messy filtering code.