### PR TITLE
Use Statement.search for stats

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,3 +1,7 @@
 class WelcomeController < ApplicationController
-  def index; end
+  include ApplicationHelper
+
+  def index
+    @stats = Statement.search(admin: admin?, criteria: {}).stats
+  end
 end

--- a/app/models/statement_search.rb
+++ b/app/models/statement_search.rb
@@ -11,6 +11,14 @@ class StatementSearch
     @statements.order('companies.name')
   end
 
+  def stats
+    {
+      statements: statements.size,
+      sectors: statements.select('companies.sector_id').distinct.count,
+      countries: statements.select('companies.country_id').distinct.count
+    }
+  end
+
   private
 
   def filter_by_published

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -48,17 +48,17 @@
 
 <section class="section">
   <div class="container">
-    <div class="columns has-text-centered">
+    <div class="columns has-text-centered" data-content="stats_counters">
       <div class="column">
-        <p class="title is-1"><%= Statement.count %></p>
+        <p class="title is-1" data-content="statements"><%= @stats[:statements] %></p>
         <p class="subtitle is-3">statements</p>
       </div>
       <div class="column">
-        <p class="title is-1"><%= Sector.with_companies.all.length %></p>
+        <p class="title is-1" data-content="sectors"><%= @stats[:sectors] %></p>
         <p class="subtitle is-3">sectors</p>
       </div>
       <div class="column">
-        <p class="title is-1"><%= Country.with_companies.all.length %></p>
+        <p class="title is-1" data-content="countries"><%= @stats[:countries] %></p>
         <p class="subtitle is-3">countries</p>
       </div>
     </div>

--- a/features/public_stats.feature
+++ b/features/public_stats.feature
@@ -1,0 +1,15 @@
+Feature: Public stats
+  Anonymous visitors can see statistics about activity
+
+  Scenario: Visitor sees counts of statements, countries and sectors
+    Given the following statements have been submitted:
+      | company_name | statement_url          | country        | sector      | published |
+      | Cucumber Ltd | https://cucumber.ltd/s | United Kingdom | Software    | Yes       |
+      | Banana Ltd   | https://banana.io/s    | France         | Agriculture | No        |
+      | Cucumber Inc | https://cucumber.inc/s | United States  | Retail      | Yes       |
+      | Cucumber Plc | https://cucumber.plc/s | United Kingdom | Software    | Yes       |
+    When Vicky views the public stats
+    Then Vicky should see the following public stats:
+      | statements | 3 |
+      | countries  | 2 |
+      | sectors    | 2 |

--- a/features/step_definitions/public_stats_steps.rb
+++ b/features/step_definitions/public_stats_steps.rb
@@ -1,0 +1,21 @@
+When(/^(Vicky) views the public stats$/) do |actor| # rubocop:disable Style/SymbolProc
+  actor.attempts_to_view_public_stats
+end
+
+Then(/^(Vicky) should see the following public stats:$/) do |actor, table|
+  expect(actor.visible_public_stats.to_h).to include(table.rows_hash.to_h.symbolize_keys)
+end
+
+module AttemptsToViewPublicStats
+  def attempts_to_view_public_stats
+    visit root_path
+  end
+
+  def visible_public_stats
+    dom_struct(:stats_counters, :statements, :countries, :sectors)
+  end
+end
+
+class Visitor
+  include AttemptsToViewPublicStats
+end

--- a/features/support/dom_struct.rb
+++ b/features/support/dom_struct.rb
@@ -12,13 +12,12 @@ module DomStruct
   #      <span data-content="surname">Hopper</span>
   #    </div>
   #
-  #    structs(browser, :person, :name, :surname) =>
+  #    dom_structs(browser, :person, :name, :surname) =>
   #      [
   #        #<struct name="Aslak" surname="Hellesøy">,
   #        #<struct name="Grace" surname="Hopper">
   #      ]
   #
-  # @param [Capybara::Driver::Base] browser The browser to interact with.
   # @param [String] struct_name The name of the struct, which has to match the parent
   #        element's +data-content+ value, in lowercase.
   # @param [Array<Symbol>] field_names The names of the struct fields, which
@@ -27,7 +26,7 @@ module DomStruct
   #
   def dom_structs(struct_name, *field_names)
     struct = Struct.new(*field_names)
-    all(%([data-content="#{struct_name}"])).map do |element|
+    all(selector(struct_name)).map do |element|
       fields = field_names.map do |field_name|
         field_value_from_element(field_name, element)
       end
@@ -37,16 +36,20 @@ module DomStruct
 
   def dom_struct(struct_name, *field_names)
     structs = dom_structs(struct_name, *field_names)
-    raise 'No structs found' if structs.empty?
-    raise "Expected a single struct, found #{structs.length}" if structs.length > 1
+    raise "No structs found for #{selector(struct_name)}" if structs.empty?
+    raise "Expected a single struct for #{selector(struct_name)}, found #{structs.length}" if structs.length > 1
     structs[0]
   end
 
   private
 
   def field_value_from_element(field_name, element)
-    element.find(%([data-content="#{field_name}"])).text
+    element.find(selector(field_name)).text
   rescue ::Capybara::ElementNotFound
     nil
+  end
+
+  def selector(name)
+    %([data-content="#{name}"])
   end
 end

--- a/features/support/statements.rb
+++ b/features/support/statements.rb
@@ -31,7 +31,7 @@ module Statements
       contributor_email: props['contributor_email'],
       verified_by: verifier,
       date_seen: props['date_seen'] || '2017-01-01',
-      published: verifier.present?
+      published: props['published'] == 'Yes' || verifier.present?
     )
   end
 end

--- a/spec/models/statement_search_spec.rb
+++ b/spec/models/statement_search_spec.rb
@@ -77,35 +77,71 @@ RSpec.describe Statement, type: :model do
     )
   end
 
-  context 'when the searcher is an admin' do
-    it 'finds latest statements ordered by company name' do
-      search = Statement.search(admin: true, criteria: {})
-      expect(search.statements).to eq([cucumber_2017, potato_2017])
+  describe '.search' do
+    context 'when the searcher is an admin' do
+      it 'finds latest statements ordered by company name' do
+        search = Statement.search(admin: true, criteria: {})
+        expect(search.statements).to eq([cucumber_2017, potato_2017])
+      end
+
+      it 'counts the statements' do
+        expect(Statement.search(admin: true, criteria: {}).stats).to eq(
+          statements: 2,
+          sectors: 2,
+          countries: 2
+        )
+        potato_2016.delete
+        expect(Statement.search(admin: true, criteria: {}).stats).to eq(
+          statements: 2,
+          sectors: 2,
+          countries: 2
+        )
+      end
     end
-  end
 
-  context 'when the searcher is not an admin' do
-    it 'finds latest published statements ordered by company name' do
-      search = Statement.search(admin: false, criteria: {})
-      expect(search.statements).to eq([cucumber_2016, potato_2016])
+    context 'when the searcher is not an admin' do
+      it 'finds latest published statements ordered by company name' do
+        search = Statement.search(admin: false, criteria: {})
+        expect(search.statements).to eq([cucumber_2016, potato_2016])
+      end
+
+      it 'counts the statements' do
+        expect(Statement.search(admin: false, criteria: {}).stats).to eq(
+          statements: 2,
+          sectors: 2,
+          countries: 2
+        )
+        potato.update!(sector: software)
+        expect(Statement.search(admin: false, criteria: {}).stats).to eq(
+          statements: 2,
+          sectors: 1,
+          countries: 2
+        )
+        potato_2016.delete
+        expect(Statement.search(admin: false, criteria: {}).stats).to eq(
+          statements: 1,
+          sectors: 1,
+          countries: 1
+        )
+      end
     end
-  end
 
-  it 'filters statements by company name' do
-    expect(Statement.search(admin: false, criteria: { company_name: 'cucum' }).statements).to eq([cucumber_2016])
-  end
+    it 'filters statements by company name' do
+      expect(Statement.search(admin: false, criteria: { company_name: 'cucum' }).statements).to eq([cucumber_2016])
+    end
 
-  it 'filters statements by countries' do
-    expect(Statement.search(admin: true, criteria: { countries: [no.id] }).statements).to eq([potato_2017])
-    expect(Statement.search(admin: false, criteria: { countries: [gb.id, no.id] }).statements).to eq(
-      [cucumber_2016, potato_2016]
-    )
-  end
+    it 'filters statements by countries' do
+      expect(Statement.search(admin: true, criteria: { countries: [no.id] }).statements).to eq([potato_2017])
+      expect(Statement.search(admin: false, criteria: { countries: [gb.id, no.id] }).statements).to eq(
+        [cucumber_2016, potato_2016]
+      )
+    end
 
-  it 'filters statements by company sectors' do
-    expect(Statement.search(admin: true, criteria: { sectors: [agriculture.id] }).statements).to eq([potato_2017])
-    expect(Statement.search(admin: false, criteria: { sectors: [agriculture.id, software.id] }).statements).to eq(
-      [cucumber_2016, potato_2016]
-    )
+    it 'filters statements by company sectors' do
+      expect(Statement.search(admin: true, criteria: { sectors: [agriculture.id] }).statements).to eq([potato_2017])
+      expect(Statement.search(admin: false, criteria: { sectors: [agriculture.id, software.id] }).statements).to eq(
+        [cucumber_2016, potato_2016]
+      )
+    end
   end
 end


### PR DESCRIPTION
We were getting inconsistent counts on the home page versus the explore page, because they were using different queries.

This extends StatementSearch so that it does stats, and uses those on the home page