### PR TITLE
Mark broken URLs as not broken

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -33,6 +33,17 @@ class StatementsController < ApplicationController
     end
   end
 
+  def mark_url_not_broken
+    unless admin?
+      render status: :forbidden, text: "Sorry, can't do that"
+      return
+    end
+    @company = company_from_params
+    @statement = @company.statements.find(params[:id])
+    @statement.update!(broken_url: false, marked_not_broken_url: true)
+    redirect_to [@company, @statement]
+  end
+
   private
 
   def company_from_params

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -59,7 +59,7 @@ class Statement < ApplicationRecord
   end
 
   def enqueue_snapshot
-    @should_enqueue_snapshot = true if url_changed?
+    @should_enqueue_snapshot = true if url_changed? || marked_not_broken_url_changed?
   end
 
   def perform_snapshot_job
@@ -72,7 +72,7 @@ class Statement < ApplicationRecord
     fetch_result = StatementUrl.fetch(url)
     self.url = fetch_result.url
     self.broken_url = fetch_result.broken_url
-    build_snapshot_from_result(fetch_result) unless broken_url
+    build_snapshot_from_result(fetch_result) unless broken_url && !marked_not_broken_url?
   end
 
   private

--- a/app/views/statements/show.html.erb
+++ b/app/views/statements/show.html.erb
@@ -25,6 +25,10 @@
                 method: :delete,
                 data: { confirm: 'Are you sure?' } %>
         <% end %>
+        <% if @statement.broken_url && admin? %>
+          <br>
+          <%= link_to 'Mark as not broken', mark_url_not_broken_company_statement_path(@statement.company, @statement), method: :post %>
+        <% end %>
         <% if @statement.verified_by %>
           <p>Authenticated by <span data-content="verified_by"><%= @statement.verified_by.name %></span></p>
         <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     get :new_statement, on: :collection, as: 'new_company_statement'
     resources :statements do
       resource :snapshot, only: :show
+      post :mark_url_not_broken, on: :member
     end
   end
 

--- a/db/migrate/20170718104813_add_marked_not_broken_url_to_statements.rb
+++ b/db/migrate/20170718104813_add_marked_not_broken_url_to_statements.rb
@@ -1,0 +1,5 @@
+class AddMarkedNotBrokenUrlToStatements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :statements, :marked_not_broken_url, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170714130014) do
+ActiveRecord::Schema.define(version: 20170718104813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,22 +63,23 @@ ActiveRecord::Schema.define(version: 20170714130014) do
   end
 
   create_table "statements", force: :cascade do |t|
-    t.integer  "company_id",                         null: false
-    t.string   "url",                                null: false
-    t.date     "date_seen",                          null: false
+    t.integer  "company_id",                            null: false
+    t.string   "url",                                   null: false
+    t.date     "date_seen",                             null: false
     t.string   "approved_by_board"
     t.string   "approved_by"
     t.boolean  "signed_by_director"
     t.string   "signed_by"
     t.boolean  "link_on_front_page"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.boolean  "broken_url"
     t.integer  "verified_by_id"
     t.boolean  "published"
     t.string   "contributor_email"
-    t.boolean  "latest",             default: false
-    t.boolean  "latest_published",   default: false
+    t.boolean  "latest",                default: false
+    t.boolean  "latest_published",      default: false
+    t.boolean  "marked_not_broken_url", default: false
     t.index ["company_id"], name: "index_statements_on_company_id", using: :btree
     t.index ["latest"], name: "index_statements_on_latest", where: "latest", using: :btree
     t.index ["latest_published"], name: "index_statements_on_latest_published", where: "latest_published", using: :btree

--- a/features/override_broken_statement_urls.feature
+++ b/features/override_broken_statement_urls.feature
@@ -1,0 +1,8 @@
+Feature: Override Broken Statement URLs
+
+  Scenario: Administrator marks broken URL as not broken
+    Given a statement was submitted for "Cucumber Ltd" that responds with a 404
+    And Patricia is logged in
+    When Patricia marks the URL for "Cucumber Ltd" as not broken
+    And Patricia views the latest snapshot of the statement for "Cucumber Ltd"
+    Then Patricia should see a JPEG snapshot of the statement for "Cucumber Ltd"

--- a/features/snapshots.feature
+++ b/features/snapshots.feature
@@ -11,4 +11,4 @@ Feature: Snapshots
   Scenario: Snapshot of HTML statement
     Given a statement was submitted for "Cucumber Ltd" that responds with HTML
     When Patricia views the latest snapshot of the statement for "Cucumber Ltd"
-    Then Patricia should see a PNG snapshot of the statement for "Cucumber Ltd"
+    Then Patricia should see a JPEG snapshot of the statement for "Cucumber Ltd"

--- a/features/step_definitions/snapshot_steps.rb
+++ b/features/step_definitions/snapshot_steps.rb
@@ -27,7 +27,7 @@ When(/^(Joe|Patricia) views the latest snapshot of the statement for "([^"]*)"$/
   actor.attempts_to_view_the_latest_snapshot(company_name: company_name)
 end
 
-Then(/^(Joe|Patricia) should see a (PDF|PNG) snapshot of the statement for "([^"]*)"$/) do |actor, format, company_name|
+Then(/^(Joe|Patricia) should see a (PDF|JPEG) snapshot of the statement for "([^"]*)"$/) do |actor, format, company_name|
   expect(actor.visible_snapshot).to eq("#{format.content_type} snapshot for statement by '#{company_name}'")
 end
 

--- a/features/support/mime_types.rb
+++ b/features/support/mime_types.rb
@@ -1,7 +1,7 @@
 mime_types = {
   'PDF' => 'application/pdf',
   'HTML' => 'text/html',
-  'PNG' => 'image/jpeg'
+  'JPEG' => 'image/jpeg'
 }
 
 class MimeType < Value.new(:format, :content_type)


### PR DESCRIPTION
Sometimes a statement URL will need a manual check. We treat it as broken, an admin checks it, then marks it as not broken. After calling it not broken, a snapshot will be queued.