### PR TITLE
Bugfix anonymous statement submissions for existing companies

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -21,7 +21,7 @@ module Admin
       if @company.statements.first.present? && @company.statements.first.url.blank?
         @company.statements = []
       end
-      @company.associate_all_statements_with_user(current_user)
+      @company.associate_all_statements_with_user(current_user) if user_signed_in?
       if @company.save
         redirect_to admin_company_path(@company)
       else

--- a/app/controllers/admin/statements_controller.rb
+++ b/app/controllers/admin/statements_controller.rb
@@ -42,7 +42,7 @@ module Admin
       @company = Company.find(params[:company_id])
       @statement = @company.statements.find(params[:id])
       if @statement.update_attributes(statement_params)
-        @statement.associate_with_user current_user
+        @statement.associate_with_user(current_user) if user_signed_in?
         @statement.save!
         redirect_to admin_company_path(@company)
       else

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -10,6 +10,7 @@ class CompaniesController < ApplicationController
 
   def create
     @company = Company.new(company_params)
+    @company.associate_all_statements_with_user(current_user) if user_signed_in?
     if @company.save
       send_submission_email
       redirect_to thanks_path

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -14,10 +14,10 @@ class StatementsController < ApplicationController
   def create
     @company = company_from_params
     @statement = @company.statements.build(statement_params)
-    @statement.associate_with_user current_user
+    @statement.associate_with_user(current_user) if user_signed_in?
 
     if @statement.save
-      redirect_to [@company, @statement]
+      redirect_to '/thanks'
     else
       render 'new'
     end

--- a/app/views/admin/statements/_fields.html.erb
+++ b/app/views/admin/statements/_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="box">
   <div class="field">
-    <%= f.label :url, class: 'label' %>
+    <%= f.label :url, 'Statement URL', class: 'label' %>
     <p class="control">
       <%= f.text_field :url, class: 'input', onchange: 'document.getElementById("open_statement_link").href = this.value' %>
 

--- a/features/step_definitions/thanks_steps.rb
+++ b/features/step_definitions/thanks_steps.rb
@@ -1,0 +1,13 @@
+Then(/^(Vicky) should see a thank you message$/) do |actor|
+  expect(actor.visible_text).to include('Thank you!')
+end
+
+module CanSeeText
+  def visible_text
+    page.text
+  end
+end
+
+class Visitor
+  include CanSeeText
+end

--- a/features/submit_statement.feature
+++ b/features/submit_statement.feature
@@ -30,6 +30,15 @@ Feature: Submit statement
       | approved_by_board  | Not explicit                               |
       | link_on_front_page | Yes                                        |
 
+  Scenario: Visitor submits statement for existing company
+    Given the company "Featurist Ltd" has been submitted
+    When Vicky submits the following statement for "Featurist Ltd":
+      | url                | https://featurist.co.uk/anti-slavery-statement |
+    Then Vicky should see a thank you message
+    When Patricia is logged in
+    Then Patricia should see 1 statement for "Featurist Ltd" with:
+      | url                | https://featurist.co.uk/anti-slavery-statement |
+
   Scenario: Administrator edits existing statement
     Given Patricia is logged in
     And Patricia has submitted the following statement:


### PR DESCRIPTION
Anonymous users could not submit new statements for existing companies. Because we were trying to associate their non-existent user account with the statement.