### PR TITLE
Require specific statement attributes in different legislations

### DIFF
--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -1,2 +1,5 @@
 class Legislation < ApplicationRecord
+  def requires_statement_attribute?(attribute)
+    requires_statement_attributes.split(',').map(&:strip).include?(attribute.to_s)
+  end
 end

--- a/app/models/statement_url.rb
+++ b/app/models/statement_url.rb
@@ -1,3 +1,8 @@
+require 'securerandom'
+require 'uri'
+require 'open-uri'
+require 'timeout'
+
 # Tries to set the URL to https if possible - even if it was entered as http.
 # This is not only more secure, but it allows the site to display the statement
 # inside an iframe. Most browsers will block non-https iframes on an https site.

--- a/app/views/admin/statements/_fields.html.erb
+++ b/app/views/admin/statements/_fields.html.erb
@@ -33,7 +33,7 @@
 
   <div class="field" data-content="Legislations">
     <%= f.label :legislations, class: 'label' %>
-    <%= f.collection_check_boxes :legislation_ids, Legislation.all, :id, :name do |m| %>
+    <%= f.collection_check_boxes :legislation_ids, Legislation.all.order(:id), :id, :name do |m| %>
       <div class="control">
         <%= m.label do %>
           <%= m.check_box %>
@@ -43,20 +43,48 @@
     <% end %>
   </div>
 
-  <div class="field" data-content="Approved by board">
-    <%= f.label :approved_by_board, class: 'label' %>
-    <label class="radio">
-      <%= f.radio_button(:approved_by_board, 'Yes') %>
-      Yes
-    </label>
-    <label class="radio">
-      <%= f.radio_button(:approved_by_board, 'No') %>
-      No
-    </label>
-    <label class="radio">
-      <%= f.radio_button(:approved_by_board, 'Not explicit') %>
-      Not explicit
-    </label>
+  <div class="columns">
+
+    <div class="field column is-narrow" data-content="Approved by board">
+      <%= f.label :approved_by_board, class: 'label' %>
+      <label class="radio">
+        <%= f.radio_button(:approved_by_board, 'Yes') %>
+        Yes
+      </label>
+      <label class="radio">
+        <%= f.radio_button(:approved_by_board, 'No') %>
+        No
+      </label>
+      <label class="radio">
+        <%= f.radio_button(:approved_by_board, 'Not explicit') %>
+        Not explicit
+      </label>
+    </div>
+
+    <div class="field column is-narrow" data-content="Signed by director">
+      <%= f.label :signed_by_director, class: 'label' %>
+      <label class="radio">
+        <%= f.radio_button(:signed_by_director, true) %>
+        Yes
+      </label>
+      <label class="radio">
+        <%= f.radio_button(:signed_by_director, false) %>
+        No
+      </label>
+    </div>
+
+    <div class="field column" data-content="Link on front page">
+      <%= f.label :link_on_front_page, class: 'label' %>
+      <label class="radio">
+        <%= f.radio_button(:link_on_front_page, true) %>
+        Yes
+      </label>
+      <label class="radio">
+        <%= f.radio_button(:link_on_front_page, false) %>
+        No
+      </label>
+    </div>
+
   </div>
 
   <div class="field">
@@ -67,20 +95,7 @@
   </div>
 
   <div class="field">
-    <label class="label">Other</label>
-
-    <div class="control">
-      <label class="checkbox">
-        <%= f.check_box(:signed_by_director) %>
-        Signed by director?
-      </label>
-    </div>
-    <div class="control">
-      <label class="checkbox">
-        <%= f.check_box(:link_on_front_page) %>
-        Link on front page?
-      </label>
-    </div>
+    <label class="label">Visibility</label>
     <div class="control">
       <label class="checkbox">
         <%= f.check_box(:published) %>

--- a/app/views/companies/_company_form.html.erb
+++ b/app/views/companies/_company_form.html.erb
@@ -3,9 +3,9 @@
     <div class="notification is-danger">
       <h2><%= pluralize(company.errors.count, "error") %> prohibited this statement from being saved:</h2>
 
-      <ul data-content="validation_errors">
+      <ul>
       <% company.errors.full_messages.each do |msg| %>
-        <li data-content="validation_error"><%= msg %></li>
+        <li data-content="validation_error"><span data-content="message"><%= msg %></span></li>
       <% end %>
       </ul>
     </div>

--- a/app/views/errors/_summary.html.erb
+++ b/app/views/errors/_summary.html.erb
@@ -2,9 +2,9 @@
   <div class="notification is-danger">
     <h2><%= pluralize(object.errors.count, "error") %> prohibited this <%= object.class.name.humanize.downcase %> from being saved:</h2>
 
-    <ul data-content="validation_errors">
+    <ul>
     <% object.errors.full_messages.each do |msg| %>
-      <li data-content="validation_error"><%= msg %></li>
+      <li data-content="validation_error"><span data-content="message"><%= msg %></span></li>
     <% end %>
     </ul>
   </div>

--- a/db/migrate/20180110102417_add_requires_statement_attributes_to_legislations.rb
+++ b/db/migrate/20180110102417_add_requires_statement_attributes_to_legislations.rb
@@ -1,0 +1,5 @@
+class AddRequiresStatementAttributesToLegislations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :legislations, :requires_statement_attributes, :string, default: '', null: false
+  end
+end

--- a/db/migrate/20180110113910_set_default_requires_statement_attributes_in_legislations.rb
+++ b/db/migrate/20180110113910_set_default_requires_statement_attributes_in_legislations.rb
@@ -1,0 +1,7 @@
+class SetDefaultRequiresStatementAttributesInLegislations < ActiveRecord::Migration[5.0]
+  def up
+    Legislation.where(name: 'UK Modern Slavery Act').update_all(
+      requires_statement_attributes: 'approved_by_board,signed_by_director,link_on_front_page'
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171218195517) do
+ActiveRecord::Schema.define(version: 20180110113910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,10 +47,11 @@ ActiveRecord::Schema.define(version: 20171218195517) do
   end
 
   create_table "legislations", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "icon",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "name",                                       null: false
+    t.string   "icon",                                       null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.string   "requires_statement_attributes", default: "", null: false
   end
 
   create_table "pages", force: :cascade do |t|

--- a/features/submit_statement.feature
+++ b/features/submit_statement.feature
@@ -70,11 +70,39 @@ Feature: Submit statement
       | Approved by board  | Yes                                        |
       | Link on front page | Yes                                        |
 
-  Scenario: Administrator submits statement with missing details
+  Scenario: Administrator publishes new statement with missing details
     Given the company "Cucumber Ltd" has been submitted
     And Patricia is logged in
+    And the legislation "UK Modern Slavery Act" requires values for the following attributes:
+      | Attribute          |
+      | Signed by director |
+      | Approved by board  |
+      | Link on front page |
     When Patricia submits the following statement for "Cucumber Ltd":
-      | Signed by director | No                                         |
-      | Approved by board  | Not explicit                               |
-      | Link on front page | Yes                                        |
-    Then Patricia should see that the statement was invalid and not saved
+      | Legislations       | UK Modern Slavery Act |
+      | Published          | Yes                   |
+    Then Patricia should see that the statement was not saved due to the following errors:
+      | Message                           |
+      | Url can't be blank                |
+      | Link on front page can't be blank |
+      | Approved by board can't be blank  |
+      | Signed by director can't be blank |
+
+  Scenario: Administrator publishes existing statement with missing details
+    Given Patricia is logged in
+    And Patricia has submitted the following statement:
+      | Company name       | Cucumber Ltd                               |
+      | Statement URL      | https://cucumber.io/anti-slavery-statement |
+    And the legislation "UK Modern Slavery Act" requires values for the following attributes:
+      | Attribute          |
+      | Signed by director |
+      | Approved by board  |
+      | Link on front page |
+    When Patricia updates the statement for "Cucumber Ltd" to:
+    | Legislations       | UK Modern Slavery Act |
+    | Published          | Yes                   |
+    Then Patricia should see that the statement was not saved due to the following errors:
+      | Message                           |
+      | Link on front page can't be blank |
+      | Approved by board can't be blank  |
+      | Signed by director can't be blank |


### PR DESCRIPTION
Patricia said, regarding statements that only relate to the "California Supply Chains Act":

> These statements to do not require the same minimum requirements As MSA statements - approval, signature, and link on homepage. An error occurs when I try to publish these statements and I assume this is because these fields are not filled in. So when only the CA legislation box is ticked, we should be able to publish without filling in the minimum requirements. 

So this PR introduces a change that will only validate statement compliance attributes when the statement is published _and_ refers to a specific legislation. Since legislations are data, this list of attributes to validate is stored on the legislation model.