### PR TITLE
Bug fix: missing attributes when admin submits company as visitor

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -40,6 +40,8 @@ class CompaniesController < ApplicationController
 
   COMPANY_ATTRIBUTES = %i[
     name
+    country_id
+    sector_id
   ].freeze
 
   STATEMENTS_ATTRIBUTES = %i[

--- a/app/views/companies/_company_tabs.html.erb
+++ b/app/views/companies/_company_tabs.html.erb
@@ -13,8 +13,8 @@
     </div>
 
     <ul class="tags">
-      <li class="tag is-dark-navy"><%= @company.country_name %></li>
-      <li class="tag is-dark-navy"><%= @company.sector_name %></li>
+      <li class="tag is-dark-navy" data_content="country"><%= @company.country_name %></li>
+      <li class="tag is-dark-navy" data_content="sector"><%= @company.sector_name %></li>
     </ul>
 
     <div class="tabs is-boxed statements-tabs">

--- a/features/submit_company.feature
+++ b/features/submit_company.feature
@@ -16,6 +16,17 @@ Feature: Submit company
     Then Patricia should see company "Cucumber Ltd"
     And Patricia should not receive a thank you for submitting email
 
+  Scenario: Administrator submits a new company
+    Given Patricia is logged in
+    When Patricia submits the following company as a visitor:
+      | Company name  | Cucumber Ltd                     |
+      | Company HQ    | United Kingdom                   |
+      | Sector        | Software                         |
+      | Statement URL | http://cucumber.io/msa-statement |
+    Then Patricia should find company "Cucumber Ltd" with:
+      | Company HQ    | United Kingdom                   |
+      | Sector        | Software                         |
+
   Scenario: Visitor submits a new company
     When Vicky submits the following company:
       | Company name  | Cucumber Ltd                     |


### PR DESCRIPTION
When an admin uses the [form usually used by public](https://www.modernslaveryregistry.org/companies/new), they see some extra fields. But those extra fields aren't persisted. This PR fixes that.