### PR TITLE
Rework public stats to count statements and companies, not countries

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,7 +2,7 @@ class WelcomeController < ApplicationController
   include ApplicationHelper
 
   def index
-    @stats = Statement.search(include_unpublished: false, criteria: {}).stats
+    @statement_stats = StatementStats.new
     @compliance_stats = ComplianceStats.compile
   end
 end

--- a/app/models/statement_stats.rb
+++ b/app/models/statement_stats.rb
@@ -1,0 +1,19 @@
+class StatementStats
+  def statements_count
+    @statements_count ||= statements.count
+  end
+
+  def companies_count
+    @companies_count ||= statements.select('companies.id').distinct.count
+  end
+
+  def sectors_count
+    statements.select('companies.sector_id').distinct.count
+  end
+
+  private
+
+  def statements
+    Statement.where(published: true).joins(:company)
+  end
+end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -50,16 +50,16 @@
   <div class="container">
     <div class="columns has-text-centered" data-content="stats_counters">
       <div class="column">
-        <p class="title is-1" data-content="statements"><%= @stats[:statements] %></p>
+        <p class="title is-1" data-content="statements"><%= @statement_stats.statements_count %></p>
         <p class="subtitle is-3">statements</p>
       </div>
       <div class="column">
-        <p class="title is-1" data-content="sectors"><%= @stats[:sectors] %></p>
+        <p class="title is-1" data-content="sectors"><%= @statement_stats.sectors_count %></p>
         <p class="subtitle is-3">sectors</p>
       </div>
       <div class="column">
-        <p class="title is-1" data-content="countries"><%= @stats[:countries] %></p>
-        <p class="subtitle is-3">countries</p>
+        <p class="title is-1" data-content="companies"><%= @statement_stats.companies_count %></p>
+        <p class="subtitle is-3">companies</p>
       </div>
     </div>
     <div class="columns has-text-centered">

--- a/features/public_stats.feature
+++ b/features/public_stats.feature
@@ -1,15 +1,16 @@
 Feature: Public stats
   Anonymous visitors can see statistics about activity
 
-  Scenario: Visitor sees counts of statements, countries and sectors
+  Scenario: Visitor sees counts of statements, companies and sectors
     Given the following statements have been submitted:
-      | Company name | Statement URL          | Country        | Sector      | Published |
-      | Cucumber Ltd | https://cucumber.ltd/s | United Kingdom | Software    | Yes       |
-      | Banana Ltd   | https://banana.io/s    | France         | Agriculture | No        |
-      | Cucumber Inc | https://cucumber.inc/s | United States  | Retail      | Yes       |
-      | Cucumber Plc | https://cucumber.plc/s | United Kingdom | Software    | Yes       |
+      | Company name | Statement URL             | Sector      | Published |
+      | Cucumber Ltd | https://cucumber.ltd/s    | Software    | Yes       |
+      | Banana Ltd   | https://banana.io/s       | Agriculture | No        |
+      | Cucumber Inc | https://cucumber.inc/s    | Retail      | Yes       |
+      | Cucumber Plc | https://cucumber.plc/2017 | Software    | Yes       |
+      | Cucumber Plc | https://cucumber.plc/2018 | Software    | Yes       |
     When Vicky views the public stats
     Then Vicky should see the following public stats:
-      | statements | 3 |
-      | countries  | 2 |
+      | statements | 4 |
+      | companies  | 3 |
       | sectors    | 2 |

--- a/features/step_definitions/public_stats_steps.rb
+++ b/features/step_definitions/public_stats_steps.rb
@@ -12,7 +12,7 @@ module ViewsPublicStats
   end
 
   def visible_public_stats
-    dom_struct(:stats_counters, :statements, :countries, :sectors)
+    dom_struct(:stats_counters, :statements, :companies, :sectors)
   end
 end
 

--- a/spec/models/statement_stats_spec.rb
+++ b/spec/models/statement_stats_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe StatementStats do
+  let! :software do
+    Sector.create! name: 'Software'
+  end
+
+  let! :broadcasting do
+    Sector.create! name: 'Broadcasting'
+  end
+
+  let! :retail do
+    Sector.create! name: 'Retail'
+  end
+
+  let! :movies do
+    Sector.create! name: 'Movies'
+  end
+
+  let! :gb do
+    Country.create! code: 'GB', name: 'United Kingdom'
+  end
+
+  let! :cucumber do
+    Company.create! name: 'Cucumber Ltd', country: gb, sector: software
+  end
+
+  let! :bbc do
+    Company.create! name: 'BBC Ltd', country: gb, sector: broadcasting
+  end
+
+  let! :itv do
+    Company.create! name: 'BBC Ltd', country: gb, sector: broadcasting
+  end
+
+  let! :tesco do
+    Company.create! name: 'Tesco Plc', country: gb, sector: retail
+  end
+
+  let! :pixar do
+    Company.create! name: 'Pixar', country: gb, sector: movies
+  end
+
+  let! :cucumber_2016 do
+    cucumber.statements.create!(
+      url: 'http://cucumber.io/2016',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: false,
+      link_on_front_page: true,
+      date_seen: Date.parse('21 May 2016'),
+      published: true,
+      contributor_email: 'someone@somewhere.com'
+    )
+  end
+
+  let! :cucumber_2017 do
+    cucumber.statements.create!(
+      url: 'http://cucumber.io/2017',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: false,
+      link_on_front_page: true,
+      date_seen: Date.parse('22 June 2017'),
+      published: true,
+      contributor_email: 'someone@somewhere.com'
+    )
+  end
+
+  let! :bbc_2016 do
+    bbc.statements.create!(
+      url: 'http://bbc.io/2016',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: 'No',
+      link_on_front_page: true,
+      date_seen: Date.parse('20 May 2016'),
+      published: true,
+      contributor_email: 'someone@somewhere.com'
+    )
+  end
+
+  let! :bbc_2017 do
+    bbc.statements.create!(
+      url: 'http://bbc.io/2017',
+      approved_by: 'Aslak',
+      approved_by_board: 'Yes',
+      signed_by_director: 'No',
+      link_on_front_page: true,
+      date_seen: Date.parse('20 May 2017'),
+      published: true,
+      contributor_email: 'someone@somewhere.com'
+    )
+  end
+
+  let! :pixar_2020 do
+    pixar.statements.create!(
+      url: 'http://pixar.io/2020',
+      approved_by: 'Josh',
+      approved_by_board: 'Yes',
+      signed_by_director: 'No',
+      link_on_front_page: true,
+      date_seen: Date.parse('20 May 2020'),
+      published: false,
+      contributor_email: 'someone@somewhere.com'
+    )
+  end
+
+  let :stats do
+    StatementStats.new
+  end
+
+  it 'counts published statements' do
+    expect(stats.statements_count).to eq(4)
+  end
+
+  it 'counts companies with published statements' do
+    expect(stats.companies_count).to eq(2)
+  end
+
+  it 'counts sectors of companies with published statements' do
+    expect(stats.sectors_count).to eq(2)
+  end
+end


### PR DESCRIPTION
Countries aren't that interesting. Now that we have more than one statement per company, we show counts of these things independently on the home page.