### PR TITLE
Limit compliance stats to particular legislations

### DIFF
--- a/app/models/compliance_stats.rb
+++ b/app/models/compliance_stats.rb
@@ -7,7 +7,7 @@ class ComplianceStats
   def self.compile
     total = 0
     counts = { approved_by_board: 0, link_on_front_page?: 0, signed_by_director?: 0, fully_compliant?: 0 }
-    Statement.latest.to_a.map do |statement|
+    Statement.latest.joins(:legislations).merge(Legislation.included_in_compliance_stats).each do |statement|
       counts.keys.each do |key|
         counts[key] += 1 if [true, 'Yes'].include? statement.send(key)
       end

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -1,4 +1,9 @@
 class Legislation < ApplicationRecord
+  has_many :legislation_statements
+  has_many :statements, through: :legislation_statements
+
+  scope(:included_in_compliance_stats, -> { where(include_in_compliance_stats: true) })
+
   def requires_statement_attribute?(attribute)
     requires_statement_attributes.split(',').map(&:strip).include?(attribute.to_s)
   end

--- a/app/models/legislation_statement.rb
+++ b/app/models/legislation_statement.rb
@@ -1,4 +1,4 @@
 class LegislationStatement < ApplicationRecord
-  belongs_to :legislation
-  belongs_to :statement
+  belongs_to :legislation, inverse_of: :legislation_statements
+  belongs_to :statement, inverse_of: :legislation_statements
 end

--- a/db/migrate/20180217165226_add_include_in_compliance_stats_to_legislations.rb
+++ b/db/migrate/20180217165226_add_include_in_compliance_stats_to_legislations.rb
@@ -1,0 +1,5 @@
+class AddIncludeInComplianceStatsToLegislations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :legislations, :include_in_compliance_stats, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20180217165315_set_default_include_in_compliance_stats.rb
+++ b/db/migrate/20180217165315_set_default_include_in_compliance_stats.rb
@@ -1,0 +1,7 @@
+class SetDefaultIncludeInComplianceStats < ActiveRecord::Migration[5.0]
+  def up
+    Legislation.where(name: 'UK Modern Slavery Act').update_all(
+      include_in_compliance_stats: true
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180110113910) do
+ActiveRecord::Schema.define(version: 20180217165315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,11 +47,12 @@ ActiveRecord::Schema.define(version: 20180110113910) do
   end
 
   create_table "legislations", force: :cascade do |t|
-    t.string   "name",                                       null: false
-    t.string   "icon",                                       null: false
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.string   "requires_statement_attributes", default: "", null: false
+    t.string   "name",                                          null: false
+    t.string   "icon",                                          null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.string   "requires_statement_attributes", default: "",    null: false
+    t.boolean  "include_in_compliance_stats",   default: false, null: false
   end
 
   create_table "pages", force: :cascade do |t|

--- a/features/compliance_stats.feature
+++ b/features/compliance_stats.feature
@@ -2,12 +2,17 @@ Feature: Compliance stats
   Administrators can retrieve statistics about compliance
 
   Background:
+    Given the following legislations exist:
+      | Name   | Include in compliance stats? |
+      | Act X  | Yes                          |
+      | Act Y  | No                           |
     Given the following statements have been submitted:
-      | Company name | Statement URL             | Date seen  | Link on front page | Signed by director | Approved by board |
-      | Cucumber Ltd | https://cucumber.io/2015  | 2015-05-05 | Yes                | Yes                | Yes               |
-      | Banana Ltd   | https://banana.io/2017    | 2017-01-01 | Yes                | Yes                | Yes               |
-      | Cucumber Ltd | https://cucumber.io/2016  | 2016-06-06 | No                 | No                 | No                |
-      | Potato Ltd   | https://potato.io/2017    | 2017-02-02 | Yes                | Yes                | No                |
+      | Company name | Statement URL     | Date seen  | Link on front page | Signed by director | Approved by board | Legislations  |
+      | A Ltd        | https://a.io/2015 | 2015-05-05 | Yes                | Yes                | Yes               | Act X         |
+      | B Ltd        | https://b.io/2017 | 2017-01-01 | Yes                | Yes                | Yes               | Act X         |
+      | A Ltd        | https://a.io/2016 | 2016-06-06 | No                 | No                 | No                | Act X         |
+      | C Ltd        | https://c.io/2017 | 2017-02-02 | Yes                | Yes                | No                | Act X, Act Y  |
+      | D Ltd        | https://d.io/2017 | 2017-02-02 | Yes                | Yes                | Yes               | Act Y         |
     And Joe is logged in
 
   Scenario: Admin views minimum compliance stats

--- a/features/step_definitions/legislation_steps.rb
+++ b/features/step_definitions/legislation_steps.rb
@@ -1,5 +1,9 @@
-Given(/^the following Legislations exist:$/) do |table|
+Given(/^the following legislations exist:$/) do |table|
   table.hashes.each do |hash|
-    Legislation.create!(name: hash['Name'], icon: hash['Name'].downcase.underscore)
+    Legislation.create!(
+      name: hash['Name'],
+      icon: hash['Name'].downcase.underscore,
+      include_in_compliance_stats: hash['Include in compliance stats?'] == 'Yes'
+    )
   end
 end

--- a/features/submit_statement.feature
+++ b/features/submit_statement.feature
@@ -3,7 +3,7 @@ Feature: Submit statement
 
   Scenario: Administrator submits statement for new company
     Given Patricia is logged in
-    And the following Legislations exist:
+    And the following legislations exist:
       | Name              |
       | Green Edibles Act |
       | Vegetables Act    |

--- a/features/support/statements.rb
+++ b/features/support/statements.rb
@@ -1,5 +1,7 @@
 module Statements
   def submit_statement(props)
+    props['Company name'] = SecureRandom.uuid unless props.include?('Company name')
+    props['Statement URL'] = 'https://' + SecureRandom.uuid unless props.include?('Statement URL')
     verifier = find_or_create_verifier(props)
     company = find_or_create_company(props)
     create_statement(company, verifier, props)
@@ -30,7 +32,8 @@ module Statements
       default_statement_attributes.merge(
         url: props.delete('Statement URL'),
         verified_by: verifier,
-        approved_by_board: props.delete('Approved by board') || 'Not explicit'
+        approved_by_board: props.delete('Approved by board') || 'Not explicit',
+        legislations: (props.delete('Legislations') || '').split(',').map { |name| Legislation.find_by!(name: name.strip) }
       ).merge(overridden_attributes(props))
     )
   end


### PR DESCRIPTION
The compliance stats chart on the home page should only show stats for statements covering the UK modern slavery act. Legislations are stored in the database, so this adds a boolean to the legislation model to determine whether statements associated with that legislation should be included in the compliance stats (and therefore the chart).