### PR TITLE
Bug fix: incorrect case of 'Not explicit' in validator

### DIFF
--- a/app/lib/yes_no_not_explicit_validator.rb
+++ b/app/lib/yes_no_not_explicit_validator.rb
@@ -1,6 +1,6 @@
 class YesNoNotExplicitValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if ['Yes', 'No', 'Not Explicit'].include? value
+    return if ['Yes', 'No', 'Not explicit'].include? value
     record.errors[attribute] << "can't be blank"
   end
 end

--- a/features/step_definitions/legislation_steps.rb
+++ b/features/step_definitions/legislation_steps.rb
@@ -3,7 +3,8 @@ Given(/^the following legislations exist:$/) do |table|
     Legislation.create!(
       name: hash['Name'],
       icon: hash['Name'].downcase.underscore,
-      include_in_compliance_stats: hash['Include in compliance stats?'] == 'Yes'
+      include_in_compliance_stats: hash['Include in compliance stats?'] == 'Yes',
+      requires_statement_attributes: hash['Requires statement attributes'] || ''
     )
   end
 end

--- a/features/submit_statement.feature
+++ b/features/submit_statement.feature
@@ -4,22 +4,22 @@ Feature: Submit statement
   Scenario: Administrator submits statement for new company
     Given Patricia is logged in
     And the following legislations exist:
-      | Name              |
-      | Green Edibles Act |
-      | Vegetables Act    |
+      | Name              | Requires statement attributes |
+      | Green Edibles Act | approved_by_board             |
+      | Vegetables Act    |                               |
     When Patricia submits the following statement:
       | Company name       | Cucumber Ltd                               |
       | Country            | United Kingdom                             |
       | Statement URL      | https://cucumber.io/anti-slavery-statement |
       | Signed by director | Yes                                        |
-      | Approved by board  | No                                         |
+      | Approved by board  | Not explicit                               |
       | Link on front page | No                                         |
       | Legislations       | Green Edibles Act, Vegetables Act          |
       | Published          | Yes                                        |
     Then Patricia should see 1 statement for "Cucumber Ltd" with:
       | Statement URL      | https://cucumber.io/anti-slavery-statement |
       | Signed by director | Yes                                        |
-      | Approved by board  | No                                         |
+      | Approved by board  | Not explicit                               |
       | Link on front page | No                                         |
       | Legislations       | Green Edibles Act, Vegetables Act          |
 


### PR DESCRIPTION
I introduced a subtle bug when I made statement validation dependent on legislations. This fixes the bug.