### PR TITLE
Add 'also covers companies' to statements

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -67,6 +67,7 @@ module Admin
       signed_by_director
       published
       contributor_email
+      also_covers_companies
     ] + [{ legislation_ids: [], year_covered: [] }]).freeze
   end
 end

--- a/app/controllers/admin/statements_controller.rb
+++ b/app/controllers/admin/statements_controller.rb
@@ -73,6 +73,7 @@ module Admin
       signed_by_director
       published
       contributor_email
+      also_covers_companies
     ] + [{ legislation_ids: [], year_covered: [] }]).freeze
   end
 end

--- a/app/views/admin/statements/_details.html.erb
+++ b/app/views/admin/statements/_details.html.erb
@@ -26,6 +26,15 @@
     </div>
   </div>
 
+  <div class="columns">
+    <div class="column is-one-quarter">
+      <span class="label">Also covers companies</span>
+    </div>
+    <div class="column" data-content="also_covers_companies">
+      <%= statement.also_covers_companies %>
+    </div>
+  </div>
+
   <% if statement.broken_url? %>
     <div class="columns">
       <div class="column is-one-quarter">

--- a/app/views/admin/statements/_fields.html.erb
+++ b/app/views/admin/statements/_fields.html.erb
@@ -31,6 +31,13 @@
     </p>
   </div>
 
+  <div class="field">
+    <%= f.label :also_covers_companies, class: 'label' %>
+    <p class="control">
+      <%= f.text_field :also_covers_companies, class: 'input' %>
+    </p>
+  </div>
+
   <div class="field" data-content="Legislations">
     <%= f.label :legislations, class: 'label' %>
     <%= f.collection_check_boxes :legislation_ids, Legislation.all.order(:id), :id, :name do |m| %>

--- a/app/views/statements/_preview.html.erb
+++ b/app/views/statements/_preview.html.erb
@@ -1,17 +1,30 @@
-<div class="statement-details">
-  <p class="date-added">
-    Legislation: <span data-content="legislation"><%= statement.legislations.map(&:name).join(', ') %></span>
-  </p>
+<div class="statement-details columns">
+  <div class="column">
+    <p>
+      Legislation: <span data-content="legislation"><%= statement.legislations.map(&:name).join(', ') %></span>
+    </p>
 
-  <p class="date-added">
-    Date added: <span data-content="date_seen"><%= l statement.date_seen, format: :long%></span>
-  </p>
+    <% if statement.verified_by %>
+      <p>Authenticated by: <span data-content="verified_by"><%= statement.verified_by.name %></span></p>
+    <% else %>
+      <p><span data-content="publish_status">Draft</span></p>
+    <% end %>
 
-  <% if statement.verified_by %>
-    <p>Authenticated by <span data-content="verified_by"><%= statement.verified_by.name %></span></p>
-  <% else %>
-    <p><span data-content="publish_status">Draft</span></p>
-  <% end %>
+    <p>
+      Added on: <span data-content="date_seen"><%= l statement.date_seen, format: :long %></span>
+    </p>
+  </div>
+
+  <div class="column is-narrow">
+    <% unless statement.also_covers_companies.blank? %>
+      <p>
+        This statement also covers the following companies:
+        <br />
+        <span data-content="also_covers_companies"><%= statement.also_covers_companies %></span>
+      </p>
+    <% end %>
+  </div>
+
 </div>
 
 <% if statement.previewable_snapshot? %>

--- a/db/migrate/20180218110244_add_also_covers_companies_to_statements.rb
+++ b/db/migrate/20180218110244_add_also_covers_companies_to_statements.rb
@@ -1,0 +1,5 @@
+class AddAlsoCoversCompaniesToStatements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :statements, :also_covers_companies, :string
+  end
+end

--- a/db/migrate/20180218114433_set_default_also_covers_companies_from_subsidiary_names.rb
+++ b/db/migrate/20180218114433_set_default_also_covers_companies_from_subsidiary_names.rb
@@ -1,0 +1,12 @@
+class SetDefaultAlsoCoversCompaniesFromSubsidiaryNames < ActiveRecord::Migration[5.0]
+  def up
+    Company.all.each do |company|
+      unless company.subsidiary_names.blank?
+        company.statements.each do |statement|
+          puts statement.inspect
+          statement.update_attributes!(also_covers_companies: company.subsidiary_names)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180217165315) do
+ActiveRecord::Schema.define(version: 20180218114433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 20180217165315) do
     t.boolean  "marked_not_broken_url", default: false
     t.integer  "first_year_covered"
     t.integer  "last_year_covered"
+    t.string   "also_covers_companies"
     t.index ["company_id"], name: "index_statements_on_company_id", using: :btree
     t.index ["latest"], name: "index_statements_on_latest", where: "latest", using: :btree
     t.index ["latest_published"], name: "index_statements_on_latest_published", where: "latest_published", using: :btree

--- a/features/step_definitions/statement_steps.rb
+++ b/features/step_definitions/statement_steps.rb
@@ -194,7 +194,7 @@ module FillsInForms
   end
 
   def text_fields
-    ['Company name', 'Subsidiary names', 'Statement URL']
+    ['Company name', 'Subsidiary names', 'Statement URL', 'Also covers companies']
   end
 
   def drop_downs
@@ -290,7 +290,7 @@ module ViewsStatementsAsAdmin
     visit admin_company_statement_path(company, company.latest_statement)
     dom_struct(:statement, :url, :verified_by, :contributor_email,
                :published, :signed_by_director, :approved_by_board, :link_on_front_page,
-               :legislations, :period_covered)
+               :legislations, :period_covered, :also_covers_companies)
   end
 end
 

--- a/features/submit_statement.feature
+++ b/features/submit_statement.feature
@@ -8,20 +8,22 @@ Feature: Submit statement
       | Green Edibles Act | approved_by_board             |
       | Vegetables Act    |                               |
     When Patricia submits the following statement:
-      | Company name       | Cucumber Ltd                               |
-      | Country            | United Kingdom                             |
-      | Statement URL      | https://cucumber.io/anti-slavery-statement |
-      | Signed by director | Yes                                        |
-      | Approved by board  | Not explicit                               |
-      | Link on front page | No                                         |
-      | Legislations       | Green Edibles Act, Vegetables Act          |
-      | Published          | Yes                                        |
+      | Company name          | Cucumber Ltd                               |
+      | Country               | United Kingdom                             |
+      | Statement URL         | https://cucumber.io/anti-slavery-statement |
+      | Signed by director    | Yes                                        |
+      | Approved by board     | Not explicit                               |
+      | Link on front page    | No                                         |
+      | Legislations          | Green Edibles Act, Vegetables Act          |
+      | Published             | Yes                                        |
+      | Also covers companies | Gherkin Holdings                           |
     Then Patricia should see 1 statement for "Cucumber Ltd" with:
-      | Statement URL      | https://cucumber.io/anti-slavery-statement |
-      | Signed by director | Yes                                        |
-      | Approved by board  | Not explicit                               |
-      | Link on front page | No                                         |
-      | Legislations       | Green Edibles Act, Vegetables Act          |
+      | Statement URL         | https://cucumber.io/anti-slavery-statement |
+      | Signed by director    | Yes                                        |
+      | Approved by board     | Not explicit                               |
+      | Link on front page    | No                                         |
+      | Legislations          | Green Edibles Act, Vegetables Act          |
+      | Also covers companies | Gherkin Holdings                           |
 
   Scenario: Administrator submits statement for existing company
     Given the company "Cucumber Ltd" has been submitted
@@ -53,22 +55,23 @@ Feature: Submit statement
   Scenario: Administrator edits existing statement
     Given Patricia is logged in
     And Patricia has submitted the following statement:
-      | Company name       | Cucumber Ltd                               |
-      | Statement URL      | https://cucumber.io/anti-slavery-statement |
-      | Signed by director | Yes                                        |
-      | Approved by board  | No                                         |
-      | Link on front page | No                                         |
-      | Published          | Yes                                        |
+      | Company name          | Cucumber Ltd                               |
+      | Statement URL         | https://cucumber.io/anti-slavery-statement |
+      | Signed by director    | Yes                                        |
+      | Approved by board     | No                                         |
+      | Link on front page    | No                                         |
+      | Published             | Yes                                        |
     When Patricia updates the statement for "Cucumber Ltd" to:
-      | Statement URL      | https://cucumber.io/updated-statement      |
-      | Signed by director | No                                         |
-      | Approved by board  | Yes                                        |
-      | Link on front page | Yes                                        |
+      | Statement URL         | https://cucumber.io/updated-statement      |
+      | Signed by director    | No                                         |
+      | Approved by board     | Yes                                        |
+      | Link on front page    | Yes                                        |
+      | Also covers companies | Gherkin Holdings                           |
     Then Patricia should see 1 statement for "Cucumber Ltd" with:
-      | Statement URL      | https://cucumber.io/updated-statement      |
-      | Signed by director | No                                         |
-      | Approved by board  | Yes                                        |
-      | Link on front page | Yes                                        |
+      | Statement URL         | https://cucumber.io/updated-statement      |
+      | Signed by director    | No                                         |
+      | Approved by board     | Yes                                        |
+      | Link on front page    | Yes                                        |
 
   Scenario: Administrator publishes new statement with missing details
     Given the company "Cucumber Ltd" has been submitted


### PR DESCRIPTION
I misunderstood a requirement to add "subsidiary names" to companies. It should have been added to statements. For now, this PR:

* Adds "also covers companies" to statements
* Copies "subsidiary names" from existing companies to each statement related to that company
* Leaves subsidiary names on companies.

We may want to remove subsidiary names from companies, but that's not clear yet.