### PR TITLE
Use all statements for each company. Fixes #41

### DIFF
--- a/app/models/statement_search.rb
+++ b/app/models/statement_search.rb
@@ -9,7 +9,7 @@ class StatementSearch
     filter_by_published
     filter_by_company
     filter_by_legislations
-    @statements.order('companies.name')
+    @statements.order('companies.name', 'date_seen DESC')
   end
 
   def stats
@@ -37,7 +37,7 @@ class StatementSearch
   end
 
   def filter_by_published
-    @statements = @include_unpublished ? @statements.latest : @statements.latest_published
+    @statements = @include_unpublished ? @statements : @statements.published
   end
 
   def filter_by_company

--- a/app/views/statements/_list.html.erb
+++ b/app/views/statements/_list.html.erb
@@ -10,6 +10,9 @@
       <div class="column" data-content="sector">
         <%= statement.sector_name %>
       </div>
+      <div class="column" data-content="period">
+        <%= statement.period_covered %>
+      </div>
     </div>
   <% end %>
   <%= paginate statements %>

--- a/spec/models/statement_search_spec.rb
+++ b/spec/models/statement_search_spec.rb
@@ -79,20 +79,20 @@ RSpec.describe Statement, type: :model do
 
   describe '.search' do
     context 'when the searcher is an admin' do
-      it 'finds latest statements ordered by company name' do
+      it 'finds all statements ordered by company name and descending publish date' do
         search = Statement.search(include_unpublished: true, criteria: {})
-        expect(search.statements).to eq([cucumber_2017, potato_2017])
+        expect(search.statements).to eq([cucumber_2017, cucumber_2016, potato_2017, potato_2016])
       end
 
       it 'counts the statements' do
         expect(Statement.search(include_unpublished: true, criteria: {}).stats).to eq(
-          statements: 2,
+          statements: 4,
           sectors: 2,
           countries: 2
         )
         potato_2016.delete
         expect(Statement.search(include_unpublished: true, criteria: {}).stats).to eq(
-          statements: 2,
+          statements: 3,
           sectors: 2,
           countries: 2
         )
@@ -102,8 +102,8 @@ RSpec.describe Statement, type: :model do
         search = Statement.search(include_unpublished: true, criteria: {})
         expect(search.sector_stats).to eq(
           [
-            GroupCount.with(group: agriculture, count: 1),
-            GroupCount.with(group: software, count: 1)
+            GroupCount.with(group: agriculture, count: 2),
+            GroupCount.with(group: software, count: 2)
           ]
         )
       end
@@ -145,7 +145,7 @@ RSpec.describe Statement, type: :model do
     it 'filters statements by countries' do
       expect(
         Statement.search(include_unpublished: true, criteria: { countries: [no.id] }).statements
-      ).to eq([potato_2017])
+      ).to eq([potato_2017, potato_2016])
       expect(
         Statement.search(include_unpublished: false, criteria: { countries: [gb.id, no.id] }).statements
       ).to eq([cucumber_2016, potato_2016])
@@ -154,7 +154,7 @@ RSpec.describe Statement, type: :model do
     it 'filters statements by company sectors' do
       expect(
         Statement.search(include_unpublished: true, criteria: { sectors: [agriculture.id] }).statements
-      ).to eq([potato_2017])
+      ).to eq([potato_2017, potato_2016])
       expect(
         Statement.search(include_unpublished: false, criteria: { sectors: [agriculture.id, software.id] }).statements
       ).to eq([cucumber_2016, potato_2016])

--- a/spec/models/statement_stats_spec.rb
+++ b/spec/models/statement_stats_spec.rb
@@ -110,8 +110,14 @@ RSpec.describe StatementStats do
     StatementStats.new
   end
 
+  let :search do
+    StatementSearch.new(false, {})
+  end
+
   it 'counts published statements' do
     expect(stats.statements_count).to eq(4)
+    # Verify that search count is consistent
+    expect(search.statements.size).to eq(4)
   end
 
   it 'counts companies with published statements' do


### PR DESCRIPTION
This change increases the number of statements displayed on the explore/search page so that the number is the same as on the front page (when no filters are enabled).

Companies that have multiple statements (for different years) will have all statements displayed in search results.