### PR TITLE
Add industry and company id to CSV for admins

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -24,6 +24,10 @@ class Company < ApplicationRecord
     try(:sector).try(:name) || 'Sector unknown'
   end
 
+  def industry_name
+    try(:industry).try(:industry_name) || ''
+  end
+
   def self.search(query)
     wild = "%#{query}%"
     Company.where(

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -66,7 +66,7 @@ class Statement < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def contributor_or_verifier_email
-    contributor_email.blank? ? verified_by_email : contributor_email
+    contributor_email.presence || verified_by_email
   end
 
   def self.to_csv(statements, extra)
@@ -117,6 +117,10 @@ class Statement < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def company_name
     company.name
+  end
+
+  def industry_name
+    company.industry_name
   end
 
   def build_snapshot_from_result(fetch_result)

--- a/app/models/statement_export.rb
+++ b/app/models/statement_export.rb
@@ -32,6 +32,8 @@ class StatementExport
     published: 'Published',
     verified_by_email: 'Verified by',
     contributor_email: 'Contributed by',
-    broken_url: 'Broken URL'
+    broken_url: 'Broken URL',
+    industry_name: 'Industry',
+    company_id: 'Company ID'
   }.freeze
 end

--- a/app/models/statement_search.rb
+++ b/app/models/statement_search.rb
@@ -5,7 +5,7 @@ class StatementSearch
   end
 
   def statements
-    @statements = Statement.includes(:verified_by, :legislations, company: %i[sector country])
+    @statements = Statement.includes(:verified_by, :legislations, company: %i[sector country industry])
     filter_by_published
     filter_by_company
     filter_by_legislations

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe Statement, type: :model do
         )
       end
       @sw = Sector.create! name: 'Software'
+      @vegetables = Industry.create!(industry_name: 'Vegetables')
       @gb = Country.create! code: 'GB', name: 'United Kingdom'
-      @company = Company.create! name: 'Cucumber Ltd', country_id: @gb.id, sector_id: @sw.id
+      @company = Company.create! name: 'Cucumber Ltd', country: @gb, sector: @sw, industry: @vegetables
     end
 
     it 'converts url to https if it exists' do
@@ -115,7 +116,7 @@ RSpec.describe Statement, type: :model do
       end
     end
 
-    it 'turns rows into CSV with more rows for admins' do
+    it 'turns rows into CSV with more columns for admins' do
       VCR.use_cassette('cucumber.io') do
         user = User.create!(first_name: 'Super',
                             last_name: 'Admin',
@@ -132,15 +133,15 @@ RSpec.describe Statement, type: :model do
                                                 verified_by: user,
                                                 contributor_email: 'contributor@somewhere.com',
                                                 date_seen: Date.parse('2017-03-22'),
-                                                published: true)
+                                                published: true,)
 
         statement.fetch_snapshot
         statement.save!
         csv = Statement.to_csv(@company.statements.includes(company: %i[sector country]), true)
 
         expect(csv).to eq(<<~CSV
-          Company,URL,Sector,HQ,Date Added,Approved by Board,Approved by,Signed by Director,Signed by,Link on Front Page,Published,Verified by,Contributed by,Broken URL
-          Cucumber Ltd,https://cucumber.io/,Software,United Kingdom,2017-03-22,Yes,Big Boss,false,Little Boss,true,true,admin@somewhere.com,contributor@somewhere.com,false
+          Company,URL,Sector,HQ,Date Added,Approved by Board,Approved by,Signed by Director,Signed by,Link on Front Page,Published,Verified by,Contributed by,Broken URL,Industry,Company ID
+          Cucumber Ltd,https://cucumber.io/,Software,United Kingdom,2017-03-22,Yes,Big Boss,false,Little Boss,true,true,admin@somewhere.com,contributor@somewhere.com,false,Vegetables,#{statement.company_id}
   CSV
                          )
       end


### PR DESCRIPTION
When the user is an administrator, add "Company ID" and "Industry" columns to the spreadsheet, so we can easily import batches of updates (like the remaining industry names for each company).