### PR TITLE
Cache pages and nav-links to reduce memory overhead

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -20,6 +20,10 @@ class Page < ApplicationRecord
     find_by!(slug: param)
   end
 
+  def self.last_changed
+    pluck(:updated_at).max
+  end
+
   def banner?
     # Banner page was used for "in memory of". Change this regexp to make other
     # pages show up as banner.

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,8 +5,8 @@
         <div class="nav-menu nav-center">
           <%= link_to 'Home', root_path, class: 'nav-item' %>
           <%= link_to 'Browse statements', explore_path, class: 'nav-item' %>
-          <% Page.as_list.each do |page| %>
-            <%= link_to page.short_title, page_path(page), class: 'nav-item' %>
+          <% nav_links.each do |title, path| %>
+            <%= link_to title, path, class: 'nav-item' %>
           <% end %>
         </div>
       </p>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -16,10 +16,8 @@
       </span>
 
       <div class="nav-right nav-menu">
-        <% Page.include_drafts(admin?).as_list.each do |page| %>
-          <% if !page.banner? %>
-            <%= link_to page.short_title, page_path(page), class: 'nav-item' %>
-          <% end %>
+        <% nav_links.each do |title, path| %>
+           <%= link_to title, path, class: 'nav-item' %>
         <% end %>
       </div>
 

--- a/db/migrate/20180707135549_add_timestamps_to_pages.rb
+++ b/db/migrate/20180707135549_add_timestamps_to_pages.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_timestamps :pages, default: Time.zone.now
+    change_column_default :pages, :created_at, nil
+    change_column_default :pages, :updated_at, nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -35,8 +36,6 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
 
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -45,7 +44,7 @@ SET default_with_oids = false;
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE active_storage_attachments (
+CREATE TABLE public.active_storage_attachments (
     id bigint NOT NULL,
     name character varying NOT NULL,
     record_type character varying NOT NULL,
@@ -59,7 +58,7 @@ CREATE TABLE active_storage_attachments (
 -- Name: active_storage_attachments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE active_storage_attachments_id_seq
+CREATE SEQUENCE public.active_storage_attachments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -71,14 +70,14 @@ CREATE SEQUENCE active_storage_attachments_id_seq
 -- Name: active_storage_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE active_storage_attachments_id_seq OWNED BY active_storage_attachments.id;
+ALTER SEQUENCE public.active_storage_attachments_id_seq OWNED BY public.active_storage_attachments.id;
 
 
 --
 -- Name: active_storage_blobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE active_storage_blobs (
+CREATE TABLE public.active_storage_blobs (
     id bigint NOT NULL,
     key character varying NOT NULL,
     filename character varying NOT NULL,
@@ -94,7 +93,7 @@ CREATE TABLE active_storage_blobs (
 -- Name: active_storage_blobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE active_storage_blobs_id_seq
+CREATE SEQUENCE public.active_storage_blobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -106,14 +105,14 @@ CREATE SEQUENCE active_storage_blobs_id_seq
 -- Name: active_storage_blobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE active_storage_blobs_id_seq OWNED BY active_storage_blobs.id;
+ALTER SEQUENCE public.active_storage_blobs_id_seq OWNED BY public.active_storage_blobs.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -125,7 +124,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: companies; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE companies (
+CREATE TABLE public.companies (
     id bigint NOT NULL,
     name character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -142,7 +141,7 @@ CREATE TABLE companies (
 -- Name: companies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE companies_id_seq
+CREATE SEQUENCE public.companies_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -154,14 +153,14 @@ CREATE SEQUENCE companies_id_seq
 -- Name: companies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE companies_id_seq OWNED BY companies.id;
+ALTER SEQUENCE public.companies_id_seq OWNED BY public.companies.id;
 
 
 --
 -- Name: countries; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE countries (
+CREATE TABLE public.countries (
     id bigint NOT NULL,
     code character varying NOT NULL,
     name character varying NOT NULL,
@@ -176,7 +175,7 @@ CREATE TABLE countries (
 -- Name: countries_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE countries_id_seq
+CREATE SEQUENCE public.countries_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -188,14 +187,14 @@ CREATE SEQUENCE countries_id_seq
 -- Name: countries_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE countries_id_seq OWNED BY countries.id;
+ALTER SEQUENCE public.countries_id_seq OWNED BY public.countries.id;
 
 
 --
 -- Name: industries; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE industries (
+CREATE TABLE public.industries (
     id bigint NOT NULL,
     sector_name character varying,
     sector_code integer,
@@ -210,7 +209,7 @@ CREATE TABLE industries (
 -- Name: industries_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE industries_id_seq
+CREATE SEQUENCE public.industries_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -222,14 +221,14 @@ CREATE SEQUENCE industries_id_seq
 -- Name: industries_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE industries_id_seq OWNED BY industries.id;
+ALTER SEQUENCE public.industries_id_seq OWNED BY public.industries.id;
 
 
 --
 -- Name: legislation_statements; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE legislation_statements (
+CREATE TABLE public.legislation_statements (
     id bigint NOT NULL,
     legislation_id integer NOT NULL,
     statement_id integer NOT NULL,
@@ -242,7 +241,7 @@ CREATE TABLE legislation_statements (
 -- Name: legislation_statements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE legislation_statements_id_seq
+CREATE SEQUENCE public.legislation_statements_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -254,14 +253,14 @@ CREATE SEQUENCE legislation_statements_id_seq
 -- Name: legislation_statements_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE legislation_statements_id_seq OWNED BY legislation_statements.id;
+ALTER SEQUENCE public.legislation_statements_id_seq OWNED BY public.legislation_statements.id;
 
 
 --
 -- Name: legislations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE legislations (
+CREATE TABLE public.legislations (
     id bigint NOT NULL,
     name character varying NOT NULL,
     icon character varying NOT NULL,
@@ -276,7 +275,7 @@ CREATE TABLE legislations (
 -- Name: legislations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE legislations_id_seq
+CREATE SEQUENCE public.legislations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -288,21 +287,23 @@ CREATE SEQUENCE legislations_id_seq
 -- Name: legislations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE legislations_id_seq OWNED BY legislations.id;
+ALTER SEQUENCE public.legislations_id_seq OWNED BY public.legislations.id;
 
 
 --
 -- Name: pages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE pages (
+CREATE TABLE public.pages (
     id bigint NOT NULL,
     title character varying NOT NULL,
     short_title character varying NOT NULL,
     slug character varying NOT NULL,
     body_html text NOT NULL,
     "position" integer NOT NULL,
-    published boolean
+    published boolean,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -310,7 +311,7 @@ CREATE TABLE pages (
 -- Name: pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE pages_id_seq
+CREATE SEQUENCE public.pages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -322,14 +323,14 @@ CREATE SEQUENCE pages_id_seq
 -- Name: pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE pages_id_seq OWNED BY pages.id;
+ALTER SEQUENCE public.pages_id_seq OWNED BY public.pages.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -338,7 +339,7 @@ CREATE TABLE schema_migrations (
 -- Name: search_aliases; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE search_aliases (
+CREATE TABLE public.search_aliases (
     id bigint NOT NULL,
     target tsquery,
     substitute tsquery
@@ -349,7 +350,7 @@ CREATE TABLE search_aliases (
 -- Name: search_aliases_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE search_aliases_id_seq
+CREATE SEQUENCE public.search_aliases_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -361,14 +362,14 @@ CREATE SEQUENCE search_aliases_id_seq
 -- Name: search_aliases_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE search_aliases_id_seq OWNED BY search_aliases.id;
+ALTER SEQUENCE public.search_aliases_id_seq OWNED BY public.search_aliases.id;
 
 
 --
 -- Name: sectors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sectors (
+CREATE TABLE public.sectors (
     id bigint NOT NULL,
     name character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -380,7 +381,7 @@ CREATE TABLE sectors (
 -- Name: sectors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sectors_id_seq
+CREATE SEQUENCE public.sectors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -392,14 +393,14 @@ CREATE SEQUENCE sectors_id_seq
 -- Name: sectors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sectors_id_seq OWNED BY sectors.id;
+ALTER SEQUENCE public.sectors_id_seq OWNED BY public.sectors.id;
 
 
 --
 -- Name: snapshots; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE snapshots (
+CREATE TABLE public.snapshots (
     id bigint NOT NULL,
     statement_id integer,
     created_at timestamp without time zone NOT NULL,
@@ -411,7 +412,7 @@ CREATE TABLE snapshots (
 -- Name: snapshots_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE snapshots_id_seq
+CREATE SEQUENCE public.snapshots_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -423,14 +424,14 @@ CREATE SEQUENCE snapshots_id_seq
 -- Name: snapshots_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE snapshots_id_seq OWNED BY snapshots.id;
+ALTER SEQUENCE public.snapshots_id_seq OWNED BY public.snapshots.id;
 
 
 --
 -- Name: statements; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE statements (
+CREATE TABLE public.statements (
     id bigint NOT NULL,
     company_id integer NOT NULL,
     url character varying NOT NULL,
@@ -459,7 +460,7 @@ CREATE TABLE statements (
 -- Name: statements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE statements_id_seq
+CREATE SEQUENCE public.statements_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -471,14 +472,14 @@ CREATE SEQUENCE statements_id_seq
 -- Name: statements_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE statements_id_seq OWNED BY statements.id;
+ALTER SEQUENCE public.statements_id_seq OWNED BY public.statements.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
@@ -506,7 +507,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -518,105 +519,105 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: active_storage_attachments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('active_storage_attachments_id_seq'::regclass);
+ALTER TABLE ONLY public.active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('public.active_storage_attachments_id_seq'::regclass);
 
 
 --
 -- Name: active_storage_blobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('active_storage_blobs_id_seq'::regclass);
+ALTER TABLE ONLY public.active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('public.active_storage_blobs_id_seq'::regclass);
 
 
 --
 -- Name: companies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq'::regclass);
+ALTER TABLE ONLY public.companies ALTER COLUMN id SET DEFAULT nextval('public.companies_id_seq'::regclass);
 
 
 --
 -- Name: countries id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY countries ALTER COLUMN id SET DEFAULT nextval('countries_id_seq'::regclass);
+ALTER TABLE ONLY public.countries ALTER COLUMN id SET DEFAULT nextval('public.countries_id_seq'::regclass);
 
 
 --
 -- Name: industries id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY industries ALTER COLUMN id SET DEFAULT nextval('industries_id_seq'::regclass);
+ALTER TABLE ONLY public.industries ALTER COLUMN id SET DEFAULT nextval('public.industries_id_seq'::regclass);
 
 
 --
 -- Name: legislation_statements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legislation_statements ALTER COLUMN id SET DEFAULT nextval('legislation_statements_id_seq'::regclass);
+ALTER TABLE ONLY public.legislation_statements ALTER COLUMN id SET DEFAULT nextval('public.legislation_statements_id_seq'::regclass);
 
 
 --
 -- Name: legislations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legislations ALTER COLUMN id SET DEFAULT nextval('legislations_id_seq'::regclass);
+ALTER TABLE ONLY public.legislations ALTER COLUMN id SET DEFAULT nextval('public.legislations_id_seq'::regclass);
 
 
 --
 -- Name: pages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pages ALTER COLUMN id SET DEFAULT nextval('pages_id_seq'::regclass);
+ALTER TABLE ONLY public.pages ALTER COLUMN id SET DEFAULT nextval('public.pages_id_seq'::regclass);
 
 
 --
 -- Name: search_aliases id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY search_aliases ALTER COLUMN id SET DEFAULT nextval('search_aliases_id_seq'::regclass);
+ALTER TABLE ONLY public.search_aliases ALTER COLUMN id SET DEFAULT nextval('public.search_aliases_id_seq'::regclass);
 
 
 --
 -- Name: sectors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sectors ALTER COLUMN id SET DEFAULT nextval('sectors_id_seq'::regclass);
+ALTER TABLE ONLY public.sectors ALTER COLUMN id SET DEFAULT nextval('public.sectors_id_seq'::regclass);
 
 
 --
 -- Name: snapshots id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY snapshots ALTER COLUMN id SET DEFAULT nextval('snapshots_id_seq'::regclass);
+ALTER TABLE ONLY public.snapshots ALTER COLUMN id SET DEFAULT nextval('public.snapshots_id_seq'::regclass);
 
 
 --
 -- Name: statements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY statements ALTER COLUMN id SET DEFAULT nextval('statements_id_seq'::regclass);
+ALTER TABLE ONLY public.statements ALTER COLUMN id SET DEFAULT nextval('public.statements_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_attachments
+ALTER TABLE ONLY public.active_storage_attachments
     ADD CONSTRAINT active_storage_attachments_pkey PRIMARY KEY (id);
 
 
@@ -624,7 +625,7 @@ ALTER TABLE ONLY active_storage_attachments
 -- Name: active_storage_blobs active_storage_blobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY active_storage_blobs
+ALTER TABLE ONLY public.active_storage_blobs
     ADD CONSTRAINT active_storage_blobs_pkey PRIMARY KEY (id);
 
 
@@ -632,7 +633,7 @@ ALTER TABLE ONLY active_storage_blobs
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -640,7 +641,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: companies companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies
+ALTER TABLE ONLY public.companies
     ADD CONSTRAINT companies_pkey PRIMARY KEY (id);
 
 
@@ -648,7 +649,7 @@ ALTER TABLE ONLY companies
 -- Name: countries countries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY countries
+ALTER TABLE ONLY public.countries
     ADD CONSTRAINT countries_pkey PRIMARY KEY (id);
 
 
@@ -656,7 +657,7 @@ ALTER TABLE ONLY countries
 -- Name: industries industries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY industries
+ALTER TABLE ONLY public.industries
     ADD CONSTRAINT industries_pkey PRIMARY KEY (id);
 
 
@@ -664,7 +665,7 @@ ALTER TABLE ONLY industries
 -- Name: legislation_statements legislation_statements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legislation_statements
+ALTER TABLE ONLY public.legislation_statements
     ADD CONSTRAINT legislation_statements_pkey PRIMARY KEY (id);
 
 
@@ -672,7 +673,7 @@ ALTER TABLE ONLY legislation_statements
 -- Name: legislations legislations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legislations
+ALTER TABLE ONLY public.legislations
     ADD CONSTRAINT legislations_pkey PRIMARY KEY (id);
 
 
@@ -680,7 +681,7 @@ ALTER TABLE ONLY legislations
 -- Name: pages pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pages
+ALTER TABLE ONLY public.pages
     ADD CONSTRAINT pages_pkey PRIMARY KEY (id);
 
 
@@ -688,7 +689,7 @@ ALTER TABLE ONLY pages
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -696,7 +697,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: search_aliases search_aliases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY search_aliases
+ALTER TABLE ONLY public.search_aliases
     ADD CONSTRAINT search_aliases_pkey PRIMARY KEY (id);
 
 
@@ -704,7 +705,7 @@ ALTER TABLE ONLY search_aliases
 -- Name: sectors sectors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sectors
+ALTER TABLE ONLY public.sectors
     ADD CONSTRAINT sectors_pkey PRIMARY KEY (id);
 
 
@@ -712,7 +713,7 @@ ALTER TABLE ONLY sectors
 -- Name: snapshots snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY snapshots
+ALTER TABLE ONLY public.snapshots
     ADD CONSTRAINT snapshots_pkey PRIMARY KEY (id);
 
 
@@ -720,7 +721,7 @@ ALTER TABLE ONLY snapshots
 -- Name: statements statements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY statements
+ALTER TABLE ONLY public.statements
     ADD CONSTRAINT statements_pkey PRIMARY KEY (id);
 
 
@@ -728,7 +729,7 @@ ALTER TABLE ONLY statements
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -736,217 +737,217 @@ ALTER TABLE ONLY users
 -- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_storage_attachments_on_blob_id ON active_storage_attachments USING btree (blob_id);
+CREATE INDEX index_active_storage_attachments_on_blob_id ON public.active_storage_attachments USING btree (blob_id);
 
 
 --
 -- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON active_storage_attachments USING btree (record_type, record_id, name, blob_id);
+CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON public.active_storage_attachments USING btree (record_type, record_id, name, blob_id);
 
 
 --
 -- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON active_storage_blobs USING btree (key);
+CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON public.active_storage_blobs USING btree (key);
 
 
 --
 -- Name: index_companies_on_country_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_companies_on_country_id ON companies USING btree (country_id);
+CREATE INDEX index_companies_on_country_id ON public.companies USING btree (country_id);
 
 
 --
 -- Name: index_companies_on_industry_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_companies_on_industry_id ON companies USING btree (industry_id);
+CREATE INDEX index_companies_on_industry_id ON public.companies USING btree (industry_id);
 
 
 --
 -- Name: index_companies_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_companies_on_name ON companies USING gist (name gist_trgm_ops);
+CREATE INDEX index_companies_on_name ON public.companies USING gist (name public.gist_trgm_ops);
 
 
 --
 -- Name: index_companies_on_sector_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_companies_on_sector_id ON companies USING btree (sector_id);
+CREATE INDEX index_companies_on_sector_id ON public.companies USING btree (sector_id);
 
 
 --
 -- Name: index_companies_on_subsidiary_names; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_companies_on_subsidiary_names ON companies USING gist (subsidiary_names gist_trgm_ops);
+CREATE INDEX index_companies_on_subsidiary_names ON public.companies USING gist (subsidiary_names public.gist_trgm_ops);
 
 
 --
 -- Name: index_countries_on_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_countries_on_code ON countries USING btree (code);
+CREATE UNIQUE INDEX index_countries_on_code ON public.countries USING btree (code);
 
 
 --
 -- Name: index_countries_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_countries_on_name ON countries USING btree (name);
+CREATE UNIQUE INDEX index_countries_on_name ON public.countries USING btree (name);
 
 
 --
 -- Name: index_legislation_statements_on_legislation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_legislation_statements_on_legislation_id ON legislation_statements USING btree (legislation_id);
+CREATE INDEX index_legislation_statements_on_legislation_id ON public.legislation_statements USING btree (legislation_id);
 
 
 --
 -- Name: index_legislation_statements_on_statement_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_legislation_statements_on_statement_id ON legislation_statements USING btree (statement_id);
+CREATE INDEX index_legislation_statements_on_statement_id ON public.legislation_statements USING btree (statement_id);
 
 
 --
 -- Name: index_pages_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pages_on_slug ON pages USING btree (slug);
+CREATE UNIQUE INDEX index_pages_on_slug ON public.pages USING btree (slug);
 
 
 --
 -- Name: index_sectors_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_sectors_on_name ON sectors USING btree (name);
+CREATE UNIQUE INDEX index_sectors_on_name ON public.sectors USING btree (name);
 
 
 --
 -- Name: index_snapshots_on_statement_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_snapshots_on_statement_id ON snapshots USING btree (statement_id);
+CREATE INDEX index_snapshots_on_statement_id ON public.snapshots USING btree (statement_id);
 
 
 --
 -- Name: index_statements_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_statements_on_company_id ON statements USING btree (company_id);
+CREATE INDEX index_statements_on_company_id ON public.statements USING btree (company_id);
 
 
 --
 -- Name: index_statements_on_latest; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_statements_on_latest ON statements USING btree (latest) WHERE latest;
+CREATE INDEX index_statements_on_latest ON public.statements USING btree (latest) WHERE latest;
 
 
 --
 -- Name: index_statements_on_latest_published; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_statements_on_latest_published ON statements USING btree (latest_published) WHERE latest_published;
+CREATE INDEX index_statements_on_latest_published ON public.statements USING btree (latest_published) WHERE latest_published;
 
 
 --
 -- Name: index_statements_on_published; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_statements_on_published ON statements USING btree (published);
+CREATE INDEX index_statements_on_published ON public.statements USING btree (published);
 
 
 --
 -- Name: index_statements_on_verified_by_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_statements_on_verified_by_id ON statements USING btree (verified_by_id);
+CREATE INDEX index_statements_on_verified_by_id ON public.statements USING btree (verified_by_id);
 
 
 --
 -- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_confirmation_token ON users USING btree (confirmation_token);
+CREATE UNIQUE INDEX index_users_on_confirmation_token ON public.users USING btree (confirmation_token);
 
 
 --
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
+CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
 
 
 --
 -- Name: legislation_statements fk_rails_0ac00a9478; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legislation_statements
-    ADD CONSTRAINT fk_rails_0ac00a9478 FOREIGN KEY (statement_id) REFERENCES statements(id);
+ALTER TABLE ONLY public.legislation_statements
+    ADD CONSTRAINT fk_rails_0ac00a9478 FOREIGN KEY (statement_id) REFERENCES public.statements(id);
 
 
 --
 -- Name: statements fk_rails_6379882950; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY statements
-    ADD CONSTRAINT fk_rails_6379882950 FOREIGN KEY (company_id) REFERENCES companies(id);
+ALTER TABLE ONLY public.statements
+    ADD CONSTRAINT fk_rails_6379882950 FOREIGN KEY (company_id) REFERENCES public.companies(id);
 
 
 --
 -- Name: companies fk_rails_75b15a5c36; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies
-    ADD CONSTRAINT fk_rails_75b15a5c36 FOREIGN KEY (country_id) REFERENCES countries(id);
+ALTER TABLE ONLY public.companies
+    ADD CONSTRAINT fk_rails_75b15a5c36 FOREIGN KEY (country_id) REFERENCES public.countries(id);
 
 
 --
 -- Name: companies fk_rails_81ca530391; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies
-    ADD CONSTRAINT fk_rails_81ca530391 FOREIGN KEY (industry_id) REFERENCES industries(id);
+ALTER TABLE ONLY public.companies
+    ADD CONSTRAINT fk_rails_81ca530391 FOREIGN KEY (industry_id) REFERENCES public.industries(id);
 
 
 --
 -- Name: statements fk_rails_a046a1d07b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY statements
-    ADD CONSTRAINT fk_rails_a046a1d07b FOREIGN KEY (verified_by_id) REFERENCES users(id);
+ALTER TABLE ONLY public.statements
+    ADD CONSTRAINT fk_rails_a046a1d07b FOREIGN KEY (verified_by_id) REFERENCES public.users(id);
 
 
 --
 -- Name: legislation_statements fk_rails_ec23f0992a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY legislation_statements
-    ADD CONSTRAINT fk_rails_ec23f0992a FOREIGN KEY (legislation_id) REFERENCES legislations(id);
+ALTER TABLE ONLY public.legislation_statements
+    ADD CONSTRAINT fk_rails_ec23f0992a FOREIGN KEY (legislation_id) REFERENCES public.legislations(id);
 
 
 --
 -- Name: snapshots fk_rails_f6d5ca8b5b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY snapshots
-    ADD CONSTRAINT fk_rails_f6d5ca8b5b FOREIGN KEY (statement_id) REFERENCES statements(id);
+ALTER TABLE ONLY public.snapshots
+    ADD CONSTRAINT fk_rails_f6d5ca8b5b FOREIGN KEY (statement_id) REFERENCES public.statements(id);
 
 
 --
@@ -1016,6 +1017,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180625161431'),
 ('20180627105355'),
 ('20180627130240'),
-('20180627172935');
+('20180627172935'),
+('20180707135549');
 
 


### PR DESCRIPTION
In several places in the app, we were selecting the
whole page table into memory, marshalling it to objects
in order to make navigation. In particular this was
happening on every page in the header and footer, and
on the home page when deciding whether to show the banner.

The page table only has 4 or so rows in it, but each row
contains the HTML for a page as text which can run to many
kilobytes. There's a suspicion that page loading might be
behind the slow start-up/release times we see on AWS and
the memory errors that we see on Heroku.

This commit adds some caching methods in the application_helper
to provide navigation and all the pages. In order to allow the
cache to be long-lived and expire when new pages are created
or old ones changed, this commit also adds timestamps to the
pages object and a class method to Page that gives you the
date of the most recent change to the pages table.