### PR TITLE
Associate a new, published statement with the current_user

### DIFF
--- a/app/controllers/admin/statements_controller.rb
+++ b/app/controllers/admin/statements_controller.rb
@@ -27,6 +27,7 @@ module Admin
 
     def create
       @statement = @company.statements.build(statement_params)
+      @statement.associate_with_user(current_user)
 
       if @statement.save
         redirect_to admin_company_path(@company)

--- a/spec/controllers/admin/statements_controller_spec.rb
+++ b/spec/controllers/admin/statements_controller_spec.rb
@@ -23,6 +23,32 @@ RSpec.describe Admin::StatementsController, type: :controller do
       statement = Statement.first
       expect(statement.additional_companies_covered).to include(company2)
     end
+
+    it 'associates a published statement with a user' do
+      post :create, params: {
+        company_id: company1,
+        statement: {
+          url: 'http://example.com/2',
+          published: true
+        }
+      }
+
+      statement = Statement.first
+      expect(statement.verified_by_id).to eq(controller.current_user.id)
+    end
+
+    it 'allows a `contributor_email` parameter to override the current_user\'s email address' do
+      post :create, params: {
+        company_id: company1,
+        statement: {
+          url: 'http://example.com/3',
+          contributor_email: "foo@bar.com"
+        }
+      }
+
+      statement = Statement.first
+      expect(statement.contributor_email).to eq("foo@bar.com")
+    end
   end
 
   describe 'PUT #update' do


### PR DESCRIPTION
Implements card: https://trello.com/c/J6JaCLi0/205-new-statement-automatically-shows-up-as-draft-when-added

When creating a new statement, if "published" is checked, the current user will be set as the statement's `#verified_by`, which causes the statement to be displayed as "Authenticated by" the current user, without having to click "Update Statement".
