### PR TITLE
Override url

### DIFF
--- a/app/controllers/admin/statements_controller.rb
+++ b/app/controllers/admin/statements_controller.rb
@@ -70,6 +70,7 @@ module Admin
     STATEMENT_ATTRIBUTES = (%i[
       id
       url
+      override_url
       linked_from
       link_on_front_page
       approved_by

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -170,6 +170,10 @@ class Statement < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def should_use_override_url?
+    !override_url.blank?
+  end
+
   private
 
   def legislation_requires?(attribute)

--- a/app/views/admin/statements/_details.html.erb
+++ b/app/views/admin/statements/_details.html.erb
@@ -28,6 +28,17 @@
     </div>
   </div>
 
+  <% if statement.should_use_override_url? %>
+    <div class="columns">
+      <div class="column is-one-quarter">
+        <span class="label">Override URL</span>
+      </div>
+      <div class="column" data-content="override_url">
+        <%= link_to statement.override_url, statement.override_url, class: 'is-url' %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="columns">
     <div class="column is-one-quarter">
       <span class="label">Period covered</span>

--- a/app/views/admin/statements/_fields.html.erb
+++ b/app/views/admin/statements/_fields.html.erb
@@ -2,9 +2,22 @@
   <div class="field">
     <%= f.label :url, 'Statement URL', class: 'label' %>
     <p class="control">
-      <%= f.text_field :url, class: 'input', onchange: 'document.getElementById("open_statement_link").href = this.value' %>
+      <%= f.text_field :url, class: 'input', onchange: "handle_override_url_change(this.value)" %>
 
       <%= link_to 'open in new tab', f.object.url, onclick: 'this.href = statement_url.value', id: 'open_statement_link', target: '_blank' %>
+      <a onclick="toggle_override_visibility();" id="toggle-override-field" style="float: right; display: <%= f.object.override_url.blank? ? "block" : "none" %>">add override</a>
+    </p>
+  </div>
+
+  <div class="field" id="override-field" style="display: <%= f.object.override_url.blank? ? "none" : "block" %>;">
+    <%= f.label :url, 'Override URL', class: 'label' %>
+    <p class="control">
+      <%= f.text_field :override_url, class: 'input', onchange: 'handle_override_url_change(this.value)' %>
+
+      <div id="override-controls" style="display: <%= f.object.override_url.blank? ? "none" : "block" %>">
+        <%= link_to 'open in new tab', f.object.override_url, id: 'open_statement_override_url_link', target: '_blank' %>
+        <a onclick="clear_override();" style="float: right">clear</a>
+      </div>
     </p>
   </div>
 
@@ -121,4 +134,26 @@ $('.chosen-select').chosen({
   no_results_text: 'No companies matching',
   width: '100%'
 })
+
+$('#statement_override_url').bind('input', function() { 
+  document.getElementById("override-controls").style.display = $(this).val().length > 0 ? 'initial' : 'none'
+});
+
+function handle_override_url_change(url) {
+  document.getElementById("open_statement_override_url_link").href = url;
+}
+
+function clear_override(event) {
+  document.getElementById("statement_override_url").value = "";
+  document.getElementById("override-controls").style.display = 'none';
+}
+
+function toggle_override_visibility() {
+  let override_field = document.getElementById("override-field");
+  if (override_field.style.display === 'none') {
+    override_field.style.display = 'block';
+  } else {
+    override_field.style.display = 'none';
+  }
+}
 </script>

--- a/app/views/statements/_preview.html.erb
+++ b/app/views/statements/_preview.html.erb
@@ -23,6 +23,7 @@
       </p>
       <br/>
     <% end %>
+ 
 
     <% if statement.additional_companies_covered_excluding(company).any? %>
       <p>
@@ -36,7 +37,15 @@
   </div>
 </div>
 
-<% if statement.previewable_snapshot? %>
+<% if statement.should_use_override_url? %>
+  <div class="browser-wrapper_override">
+    <div>View website:</div>
+    <div>
+      <%= link_to(statement.override_url, statement.override_url, class: 'url', target: '_blank') %>
+    </div>
+  </div>
+
+<% elsif statement.previewable_snapshot? %>
   <div class="browser-wrapper">
     <div class="browser-navigation-bar">
       <i class="top-bar"></i>

--- a/app/views/statements/_preview.html.erb
+++ b/app/views/statements/_preview.html.erb
@@ -23,7 +23,6 @@
       </p>
       <br/>
     <% end %>
- 
 
     <% if statement.additional_companies_covered_excluding(company).any? %>
       <p>

--- a/db/migrate/20191019141132_add_override_url_to_statements.rb
+++ b/db/migrate/20191019141132_add_override_url_to_statements.rb
@@ -1,0 +1,5 @@
+class AddOverrideUrlToStatements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :statements, :override_url, :string, default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -497,7 +497,8 @@ CREATE TABLE public.statements (
     marked_not_broken_url boolean DEFAULT false,
     first_year_covered integer,
     last_year_covered integer,
-    company_id bigint NOT NULL
+    company_id bigint NOT NULL,
+    override_url character varying
 );
 
 
@@ -1097,6 +1098,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190221165142'),
 ('20190225171707'),
 ('20190304105224'),
-('20190515183222');
+('20190515183222'),
+('20191019141132');
 
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -290,4 +290,24 @@ RSpec.describe Statement, type: :model do
       end
     end
   end
+
+  describe '#should_use_override_url?' do
+    context 'when the statement has an `override_url`' do
+      let(:company) { Company.create!(name: 'company') }
+      let(:statement_with_override) { company.statements.create!(url: 'http://example.com', override_url: 'http://example.com/override') }
+  
+      it 'returns `true`' do
+        expect(statement_with_override.should_use_override_url?).to be true
+      end
+    end
+
+    context 'when the statement does not have an `override_url` (e.g., !override_url.blank?)' do
+      let(:company_no_override) { Company.create!(name: 'company-no-override') }
+      let(:statement_no_override) { company_no_override.statements.create!(url: 'http://example.com') }
+
+      it 'returns `false`' do
+        expect(statement_no_override.should_use_override_url?).to be false
+      end
+    end
+  end
 end

--- a/spec/views/admin/statements/_details.html.erb_spec.rb
+++ b/spec/views/admin/statements/_details.html.erb_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe 'admin/statements/_details.html.erb', type: :view do
   let(:company) { stub_model(Company, name: 'company-name') }
   let(:statement) { stub_model(Statement, company: company, url: 'http://example.com') }
 
+  let(:company_with_override) { stub_model(Company, name: 'company-name-override-url') }
+  let(:statement_with_override) { stub_model(Statement, company: company_with_override, url: 'http://example.com', override_url: 'http://example.com/override') }
+
   it 'links to the company that produced the statement' do
     render partial: 'details', locals: { company: company, statement: statement }
 
@@ -19,5 +22,12 @@ RSpec.describe 'admin/statements/_details.html.erb', type: :view do
 
     url = admin_company_path(another_company)
     expect(rendered).to have_css("div[data-content='additional_companies'] a[href='#{url}']", text: 'another-company')
+  end
+
+  it 'shows a Statement\'s the override URL' do
+    render partial: 'details', locals: { company: company_with_override, statement: statement_with_override }
+
+    override_url = statement_with_override.override_url
+    expect(rendered).to have_css("div[data-content='override_url'] a[href='#{override_url}']", text: override_url)
   end
 end


### PR DESCRIPTION
Implements card: https://trello.com/c/W5RrZaos/204-snapshot-not-always-collected

This PR adds:
- an `override_url` column (string) to the Statement model via rails migration/structure.sql
- model instance method
- controller, view - add override_url field to user and admin views
- specs - update existing and add new

`override_url` is nil by default. When it is nil, the view behavior is the same as before.

When `override_url` has a value, it's assumed that the value is a URL that should be presented to the end user in place of the the rendered snapshot or other type of preview. Therefore, override_url may be used to prevent the end user rom seeing a broken preview render or link.

User interface:
![image](https://user-images.githubusercontent.com/740379/67306568-31a2d380-f4c5-11e9-9e6c-47769ac86ab6.png)

Management interface:
![image-1](https://user-images.githubusercontent.com/740379/67306628-4aab8480-f4c5-11e9-9c5c-4c33bc4a4378.png)

