### PR TITLE
Latest postgres CI fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
 
 services:
   - name: redis:3.2.11
-  - name: postgres:9.6-alpine
+  - name: postgres:9.6.16-alpine
     alias: postgres
 
 stages:


### PR DESCRIPTION
* pinned postgres 9.6.16 version to fix CI errors.