### PR TITLE
Updating rake task and data for audit data import (part 2)

### DIFF
--- a/lib/tasks/fixtures/audit/statements.csv
+++ b/lib/tasks/fixtures/audit/statements.csv
@@ -1,4 +1,4 @@
-﻿id,url,date_seen,approved_by_board,approved_by,signed_by_director,signed_by,link_on_front_page,created_at,updated_at,broken_url,verified_by_id,published,contributor_email,marked_not_broken_url,first_year_covered,last_year_covered,company_id,related_companies
+id,url,date_seen,approved_by_board,approved_by,signed_by_director,signed_by,link_on_front_page,created_at,updated_at,broken_url,verified_by_id,published,contributor_email,marked_not_broken_url,first_year_covered,last_year_covered,company_id,related_companies
 ,https://www.2agriculture.com/wp-content/uploads/2019/04/Slavery-and-Human-Trafficking-statement-April-19-signed.pdf,43657,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,27750,
 ,https://www.prestonmotorcycles.co.uk/slavery-statement,43817,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW5335,
 ,https://www.3stepit.com/sites/default/files/modern_slavery_statement_2018.pdf,43817,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW5337,
@@ -4846,9 +4846,9 @@
 ,https://42absd1hf6kq42oi1r2grhtz-wpengine.netdna-ssl.com/wp-content/uploads/2019/04/2018-11-UDG-Anti-Modern-Slavery-Statement1.pdf,43839,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,24258,NEW0008
 ,https://a0.muscache.com/static/uk-modern-slavery-act-statement.pdf,43791,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22868,NEW0009
 ,https://www.abellio.co.uk/media/1733/anti-slavery-2018.pdf,43688,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0015,NEW0014
-,https://www.abf.co.uk/documents/pdfs/2019/ar2019/abf_2019_modern-slavery-act-statement.pdf,43788,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,6888,"2,349,132,593"
+,https://www.abf.co.uk/documents/pdfs/2019/ar2019/abf_2019_modern-slavery-act-statement.pdf,43788,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,6888,"23491,32593"
 ,https://about.bankofamerica.com/assets/pdf/Modern-Slavery-Act.pdf,43796,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,25446,25447
-,https://about.iceland.co.uk/modern-slavery-statement/,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,22189,"2,558,025,581"
+,https://about.iceland.co.uk/modern-slavery-statement/,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,22189,"25580,25581"
 ,https://www.about.sainsburys.co.uk/~/media/Files/S/Sainsburys/SAINS3471_2019%20Modern%20Slavery%20Report_V8.pdf,43790,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9012,"24845,NEW0028,NEW0029,NEW0030,NEW0031"
 ,https://www.accord-healthcare.com/sites/default/files/accord_modern_slavery_statement_100419_final.pdf,43657,No,Executive Vice President,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10796,NEW0035
 ,http://www.acplc.net/modern-slavery/Modern_Slavery_Policy.pdf,43817,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,28129,28130
@@ -4870,8 +4870,8 @@
 ,https://www.alvarezandmarsal.com/sites/default/files/legal-uk_modern_slavery_fact_sheet_june2019_0.pdf,43657,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17144,NEW0108
 ,https://ambertaverns.co.uk/modern-slavery-act/,43767,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0109,NEW0110
 ,https://www.amecfw.com/documents/downloads/about-us/modern-slavery-statement_rgb-004.pdf,43657,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,6951,NEW0112
-,https://www.americanexpress.com/content/dam/amex/uk/legal/2018_MSA_Statement.pdf,43657,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10621,"2,365,423,656"
-,https://www.amey.co.uk/media/5345/2018_msa_statement.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10466,"251,872,519,025,191,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000"
+,https://www.americanexpress.com/content/dam/amex/uk/legal/2018_MSA_Statement.pdf,43657,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10621,"23654,23656"
+,https://www.amey.co.uk/media/5345/2018_msa_statement.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10466,"25187,25190,25191,25192,25194,26853,26854,26856,26857,26858,26859,26860,26861,26862,26863"
 ,https://www.amigoloans.co.uk/modern-slavery-statement,43819,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0135,"NEW0136,NEW0134,NEW0137"
 ,https://www.aminocom.com/company/slavery-and-human-trafficking-statement,43819,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW0138,NEW0139
 ,https://www.amphilliptrucktech.co.uk/modern-slavery,43817,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW0143,NEW0144
@@ -4879,7 +4879,7 @@
 ,http://www.apachecorp.com/Resources/Upload/file/UK/Apache_Modern_Slavery_Act_Transparency_Statement.pdf,43780,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23870,NEW0167
 ,https://apigroup.com/wp-content/uploads/2019/07/Modern-Slavery-Act-Statement-2019.pdf,43838,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9206,24895
 ,https://www.apogeecorp.com/wp-content/uploads/2019/01/Modern-Slavery-Statement.pdf,43657,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10427,NEW0171
-,https://www.apple.com/supplier-responsibility/pdf/Apple-Combat-Human-Trafficking-and-Slavery-in-Supply-Chain-2018.pdf,43839,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,24344,"2,434,524,346"
+,https://www.apple.com/supplier-responsibility/pdf/Apple-Combat-Human-Trafficking-and-Slavery-in-Supply-Chain-2018.pdf,43839,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,24344,"24345,24346"
 ,https://www.arcadis.com/media/B/7/C/%7BB7C5E538-7A5A-41B5-BEF4-B598D1105ECC%7DARCADIS%20UK%20MODERN%20SLAVERY%20AND%20HUMAN%20TRAFFICKING%20STATEMENT%202018%20FINAL.pdf,43688,No,Director,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9431,"23630,NEW0179,NEW0180"
 ,https://www.arconic.com/global/en/pdf/uk-slavery-and-human-trafficking-statement.pdf,43750,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0181,"NEW0182,NEW0183"
 ,https://www.ardonagh.com/modern-slavery-act-statement,43843,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0184,NEW0185
@@ -4891,25 +4891,25 @@
 ,https://www.ascenti.co.uk/modern-slavery-statement,43688,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21033,NEW0214
 ,https://ascotgroup.com/anti-slavery-statement,43780,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW0215,NEW0216
 ,http://www.ashmoregroup.com/sites/default/files/uploaded-docs/Modern%20Slavery%20Act%20statement%202019.pdf,43838,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0217,NEW0218
-,https://www.aspen.co/aspen-modern-slavery-act-statement/,43688,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,10458,"2,354,923,550"
+,https://www.aspen.co/aspen-modern-slavery-act-statement/,43688,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,10458,"23549,23550"
 ,https://assets.cmcmarkets.com/pdfs/Modern-Slavery-Statement-year-ending-March-2019.pdf,43657,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7220,NEW0225
 ,https://assets.contentstack.io/v3/assets/blt09078e271abddd45/blt1159f2247d5a25ba/5d31893a0bbb1819f4df7fc2/modern-slavery-report-2019.pdf#xd_co_f=NGQzNDhkOTAtYmI1Yy00M2YwLWI3MDQtNzUyNTg4YmJlZTYy~,43829,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0226,"NEW0227,NEW0228"
-,https://assets.ctfassets.net/z0vjjzshbxiz/ZEm7FwcElkHKkSNZ49tKA/f7717ee0cf67523390d0da665f644ea8/2018_PUBLISHED_Drax_modern_slavery_statement.pdf,43750,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24507,"2,450,924,511"
+,https://assets.ctfassets.net/z0vjjzshbxiz/ZEm7FwcElkHKkSNZ49tKA/f7717ee0cf67523390d0da665f644ea8/2018_PUBLISHED_Drax_modern_slavery_statement.pdf,43750,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24507,"24509,24511"
 ,https://assets.website-files.com/5ce430d94b134246b535d54d/5d9f81d8edb4fe30e7dc8dde_NEP%20Modern%20Slavery%20Statement%202019.pdf,43766,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW0234,NEW0235
 ,https://www.asta-uk.com/modern-slavery-statement/,43688,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9391,24641
 ,http://www.atg.co.uk/corporate-information/atg-modern-slavery-human-trafficking-statement/,43822,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,24222,NEW0245
-,https://www.availablecar.com/Corporate,43788,Yes,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,21326,"2,511,525,116"
+,https://www.availablecar.com/Corporate,43788,Yes,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,21326,"25115,25116"
 ,https://www.avanthomes.co.uk/modern-slavery-statement/,43828,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0249,"NEW0250,NEW0251"
 ,https://www.avarafoods.co.uk/getmedia/e508b1c8-4963-4d34-ba89-d6463266c41c/Modern-Slavery-Statement-Website-Apr-2018.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9798,NEW0253
 ,https://www.avon-rubber.com/media/1576/2019-modern-slavery-statement.pdf,43688,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,8742,NEW0280
-,https://www.axa.co.uk/msa/,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23327,"2,601,026,012"
+,https://www.axa.co.uk/msa/,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23327,"26010,26012"
 ,https://axaxl.com/-/media/axaxl/files/pdfs/about-us/corporate-responsibility/modern-slavery-act-statement.pdf,43824,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2017,23700,NEW0287
 ,https://www.bakermckenzie.com/-/media/files/locations/london/modern_slavery_statement.pdf?la=en,43794,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW0319,NEW0320
 ,https://www.bandvulc.co.uk/wp-content/uploads/2019/05/Continental-Modern-Slavery-Policy-2019.pdf,43795,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,27225,27240
 ,https://www.banksgroup.co.uk/core/uploads/Banks-Groups-Modern-Slavery-Act-2015-statement-updated-March-2019.pdf,43567,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10540,18475
 ,https://www.barnardos.org.uk/modern-slavery-statement.htm,43719,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,7035,NEW0334
 ,https://www.barrattdevelopments.co.uk/~/media/Files/B/Barratt-Developments/policies/2020/Modern%20slavery%20and%20human%20trafficking%20statement%209-2019.pdf,43719,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7038,"28625,28627,28628,28629,28632,NEW0340"
-,https://www.bat.com/group/sites/uk__9d9kcy.nsf/vwPagesWebLive/DOAK8P7C/$FILE/medMDBA3JHG.pdf?openelement,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7105,"286,142,861,528,616,000,000,000,000,000,000,000,000,000,000"
+,https://www.bat.com/group/sites/uk__9d9kcy.nsf/vwPagesWebLive/DOAK8P7C/$FILE/medMDBA3JHG.pdf?openelement,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7105,"28614,28615,28616,28617,28618,28619,28621,28622,28623"
 ,https://www.bbcstudios.com/modern-slavery-statement,43768,No,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0357,NEW0358
 ,https://www.bcamarketplace.com/corporate-responsibility/modern-slavery-act,43719,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10725,"NEW0364,NEW0365,NEW0367,NEW0368"
 ,https://www.bd.com/documents/corporate/BD_MSA%20Statement%20FY2018.pdf,43795,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,17407,"21239,NEW0371"
@@ -4917,7 +4917,7 @@
 ,https://beal-homes.co.uk/legals/modern-slavery-and-human-trafficking-statement,43796,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0374,NEW0375
 ,https://www.beautybay.com/s/anti-slavery-policy/,43790,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,22025,25525
 ,https://www.beazley.com/Documents/About%20Beazley/beazley-modern-slavery-act-statement.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,8909,"25251,NEW0378"
-,https://www.beazley.com/documents/About%20Beazley/beazley-modern-slavery-act-statement.pdf,43795,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW0378,"908,028,080"
+,https://www.beazley.com/documents/About%20Beazley/beazley-modern-slavery-act-statement.pdf,43795,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW0378,"9080,28080"
 ,https://www.bechtel.com/getattachment/Footer/Modern-Day-Slavery-Act-Statement/Signed-MSA-Statement-BLTD-and-BMCL.pdf,43795,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9080,28080
 ,http://www.beckinteriors.com/wp-content/uploads/2019/01/Modern-Slavery-Policy-Dec-2018.pdf,43810,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0383,"NEW0384,NEW0385"
 ,http://www.beeswift.co.uk/Other/Certificates/HTASPol.pdf,43719,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,7054,NEW0387
@@ -4928,10 +4928,10 @@
 ,https://www.biffa.co.uk/-/media/files/sustainability/csr/modern-slavery-statement-august-2019-vfinal.ashx,43795,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0402,NEW0403
 ,https://www.blmlaw.com/images/uploaded/File/FY2018-19.pdf,43795,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,18871,25958
 ,https://www.booker.co.uk/graphics/private/Modern_Slavery_Statement/ModernSlaveryStatement_2018-2019.pdf,43796,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,23706,"NEW0426,NEW0427,NEW0428,NEW0429"
-,https://www.bosch.co.uk/modern-slavery-statement/,43657,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9743,"1,716,028,312"
+,https://www.bosch.co.uk/modern-slavery-statement/,43657,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9743,"17160,28312"
 ,https://www.bosch.co.uk/modern-slavery-statement/?prevent-auto-open-privacy-settings=1,43795,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,28304,28313
 ,https://www.boussard-gavaudan.com/UserFiles/BG%20Group%20Anti-modern%20slavery%20statement.pdf,43791,Yes,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,22555,NEW0435
-,https://www.bouygues-es.co.uk/sites/uk/files/modern_slavery_act_bouygues_es_2019-compressed.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17705,"2,417,024,171"
+,https://www.bouygues-es.co.uk/sites/uk/files/modern_slavery_act_bouygues_es_2019-compressed.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17705,"24170,24171"
 ,https://bpl-global.com/modern-slavery-act-statement/,43795,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0466,NEW0467
 ,https://www.braidco.com/wp-content/uploads/2019/03/Braid-Modern-Slavery-Statement.pdf,43795,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,26639,26640
 ,https://www.branston.com/downloads/UK_Modern_Slavery_Act_-_Annual_statement_18_19.pdf,43780,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,10599,22466
@@ -4939,7 +4939,7 @@
 ,https://www.breyergroup.co.uk/download/pdf/Modern-Slavery-Statement-Nov-2019.pdf,43780,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17639,NEW0481
 ,http://bridgepoint.eu/media/2669088/2018_bridgepoint_modern_slavery_statement_may_2019.pdf,43768,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17411,24088
 ,https://briggsandforrester.co.uk/sites/default/files/Signed%20Modern%20Slavery%20Policy%20Statement%20April%202019.pdf,43796,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW0486,"NEW0487,NEW0488"
-,https://www.bristolstreet.co.uk/custom/71000.pdf,43790,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21164,"2,469,824,699"
+,https://www.bristolstreet.co.uk/custom/71000.pdf,43790,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21164,"24698,24699"
 ,https://www.bristolwater.co.uk/wp-content/uploads/2019/04/Modern-Slavery-Statement-2019.pdf,43810,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9419,27557
 ,https://www.britax-roemer.co.uk/legal-msas-2018/legal-msas-2018.html,43810,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17803,24191
 ,https://www.british-business-bank.co.uk/transparency/british-business-bank-plc-modern-slavery-act-statement/,43810,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,16733,26190
@@ -4992,7 +4992,7 @@
 ,https://www.ciceley.com/assets/Uploads/Ciceley-Modern-Slavery-Policy-and-Statement-Signed-Copy-Dec18.pdf,43508,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0683,NEW0684
 ,https://www.cineworldplc.com/en/about-us/modern-slavery-act,43797,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0685,NEW0686
 ,https://cis-security.co.uk/site/assets/files/1266/modern_slavery_and_human_trafficking_statement-1.pdf,43797,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7204,NEW0687
-,https://www.citibank.co.uk/static/documents/Citi_FY2018_UK_MSA_Statement_Final.pdf,43791,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24837,"2,483,824,839"
+,https://www.citibank.co.uk/static/documents/Citi_FY2018_UK_MSA_Statement_Final.pdf,43791,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24837,"24838,24839"
 ,https://www.claimsconsortiumgroup.co.uk/about-us/social-responsibility/#modernSlavery,43816,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0694,NEW0695
 ,https://clarkcontracts.com/docs/063_454__modernslaverystatement_1557241020.pdf,43782,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10834,NEW0698
 ,https://www.clarksonevans.co.uk/2019-modern-slavery-and-human-trafficking-statement,43508,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW0700,NEW0701
@@ -5000,7 +5000,7 @@
 ,https://www.clinical.catalent.com/wp-content/uploads/2019/05/Modern-Slavery-Statement.pdf,43798,No,Audit Committee,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW0707,NEW0708
 ,https://cloudfmgroup.com/files/CloudFM_Modern_Slavery_Policy.pdf,43508,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW0714,NEW0715
 ,https://www.cloudreach.com/en/legal/modern-slavery-act/,43508,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW0716,NEW0717
-,https://www.cnahardy.com/site-services/modern-slavery-act-statement,43797,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10927,"238,412,384,223,844"
+,https://www.cnahardy.com/site-services/modern-slavery-act-statement,43797,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10927,"23841,23842,23844"
 ,http://www.cnri-northsea-decom.com/CNRI-Modern-Slavery-Statement.pdf,43782,No,Leadership Team,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22411,25950
 ,http://www.cobrabeer.com/-/media/molson-coors-international/cobrabeer/files/pdf-files/cobra-beer-partnership-modern-slavery-statement-2018.ashx,43810,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,19000,26770
 ,https://www.coinford.co.uk/modern-slavery-statement/,43508,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW0726,"NEW0727,NEW0728,NEW0729"
@@ -5021,11 +5021,11 @@
 ,https://corporate.arcelormittal.com/~/media/Files/A/ArcelorMittal/sdr2016/modern-slavery-statement.pdf,43819,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0773,"NEW0774,NEW0775,NEW0776"
 ,https://corporate.danone.co.uk/uploads/tx_bidanonepublications/Danone_33051_Modern_Slavery_Statement_Web.pdf,43819,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0782,"NEW0783,NEW0784"
 ,http://corporate.ppg.com/getmedia/da66b5ff-e343-4b1c-96d4-213e2650218f/PPG-Industries-UK-Modern-Slavery-and-Human-Trafficking-Statement-2017.aspx,43750,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9321,23959
-,https://corporate.superdry.com/sustainability/modern-slavery-statement/,43812,No,Interim CEO,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,8278,"277,222,772,327,724"
+,https://corporate.superdry.com/sustainability/modern-slavery-statement/,43812,No,Interim CEO,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,8278,"27722,27723,27724"
 ,https://www.countrysideproperties.com/media/5923/download,43838,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7257,"NEW0811,NEW0812,NEW0814,NEW0815"
 ,https://www.coveainsurance.co.uk/media/2821/modern-slavery-statement-for-2018.pdf,43536,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0816,NEW0817
 ,https://www.coveris.com/assets/downloads/Modern_Slavery_Act_-_Coveris_UK_2019.pdf,43536,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0818,NEW0819
-,http://www.coxauto.co.uk/media/1614/modern-slavery-statement-2019.pdf,43689,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,28203,"2,820,428,205"
+,http://www.coxauto.co.uk/media/1614/modern-slavery-statement-2019.pdf,43689,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,28203,"28204,28205"
 ,http://www.cpi-print.co.uk/wp-content/uploads/2019/04/Modern-Slavery-Act-2015-s.-541-Statement-2019-20.pdf,43536,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0823,NEW0824
 ,http://www.cpukgroup.co.uk/cpuk-group-modern-slavery-and-human-trafficking-statement/,43782,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW0828,NEW0827
 ,https://www.cqscapital.com/documents/slavery-and-human-trafficking-statement-2019.pdf,43798,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,10953,23864
@@ -5055,7 +5055,7 @@
 ,https://www.desiragroup.com/about-us/anti-slavery-statement-/,43784,No,Managing Director,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,21682,25414
 ,https://www.devere.co.uk/sites/default/files/pdfs/modern_slavery_policy_statement_2018.pdf,43845,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0904,NEW0905
 ,https://www.devro.com/media/1287/published-modern-slavery-statement-2018.pdf,43784,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7313,NEW0906
-,https://www.dicklovett.co.uk/modern-slavery-statement,43784,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9827,"2,344,526,283"
+,https://www.dicklovett.co.uk/modern-slavery-statement,43784,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9827,"23445,26283"
 ,https://www.dicklovettbathmini.co.uk/media/4804/modern-slavery-statement-dick-lovett-bath-ltd.pdf,43597,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23444,26282
 ,https://www.dinnages.co.uk/modern-slavery-act.aspx,43597,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW0915,NEW0916
 ,https://www.diomedgroup.co.uk/modern-slavery.html,43784,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,19040,NEW0917
@@ -5074,14 +5074,14 @@
 ,https://dunbia.com/app/uploads/2019/05/Dunbia-Modern-Slavery-and-Human-Trafficking-Statement-2019.pdf,43783,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0955,"NEW0956,NEW0957,NEW0959,NEW0958"
 ,https://www.dyson.co.uk/inside-dyson/corporate-social-responsibility/modern-slavery-statement.html,43784,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8995,24679
 ,https://eastern.claas-dealer.co.uk/storage/uploads/kcfinder/dealer/2/images/Modern%20Slavery%20Statement.pdf,43508,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW0962,NEW0963
-,https://www.ecomtrading.com/wp-content/uploads/2019/06/Modern-Slavery-statement-YE-31-12-18_website-version.pdf,43799,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,25182,"2,518,325,426"
+,https://www.ecomtrading.com/wp-content/uploads/2019/06/Modern-Slavery-statement-YE-31-12-18_website-version.pdf,43799,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,25182,"25183,25426"
 ,https://www.ecotricity.co.uk/content/download/8283/93407,43628,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW0967,NEW0968
 ,https://www.edfenergy.com/about/modern-slavery-statement,43628,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW0969,"NEW0970,NEW0971"
 ,https://www.edfenergy.com/sites/default/files/newfri.pdf,43786,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9087,"NEW0972,NEW0974"
 ,https://www.edrington.com/media/1453/modern-slavery-and-human-trafficking-statement-2019.pdf,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,7357,"NEW0985,NEW0986"
 ,https://www.egcarter.co.uk/asset/3111/download,43784,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,9785,NEW0989
 ,https://www.egertoncapital.com/legal/modern-slavery-act-transparency-statement,43477,No,Management Committee,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21350,25162
-,https://www.eisai.eu/wp-content/uploads/Eisai-Modern-Slavery-Statement-2018-2019.pdf,43786,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,10808,"2,376,723,768"
+,https://www.eisai.eu/wp-content/uploads/Eisai-Modern-Slavery-Statement-2018-2019.pdf,43786,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,10808,"23767,23768"
 ,https://www.element.com/-/media/files/modern-slavery-policy/element-modern-slavery-statement-2018.pdf?la=en,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,18708,23467
 ,https://www.elim.org.uk/Articles/545535/Modern_Slavery_Statement.aspx,43628,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1003,NEW1004
 ,https://www.engie.co.uk/wp-content/uploads/2019/06/modern-slavery-statement-2018.pdf,43783,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,26000,NEW1008
@@ -5095,7 +5095,7 @@
 ,https://www.essentracomponents.com/.assetdam/245784,43720,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1050,"NEW1051,NEW1052"
 ,https://www.essity.com/Images/Untitled_18042019_135807_tcm339-75241.pdf,43720,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW1053,NEW1054
 ,http://eu.aviagen.com/assets/Headers/Product-Page-Headers/About-Us/AviagenStatementOnModernSlavery2019.pdf,43828,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,9515,NEW1058
-,https://eumultisiteprod-live-b03cec4375574452b61bdc4e94e331e7-16cd684.s3-eu-west-1.amazonaws.com/filer_public/e0/27/e027e3f9-05e8-4de8-889f-a60e81bda045/modern-slavery-human-trafficking-statement.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,7420,"22,953,229,542,295,500,000"
+,https://eumultisiteprod-live-b03cec4375574452b61bdc4e94e331e7-16cd684.s3-eu-west-1.amazonaws.com/filer_public/e0/27/e027e3f9-05e8-4de8-889f-a60e81bda045/modern-slavery-human-trafficking-statement.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,7420,"22953,22954,22955,22956"
 ,https://www.eurofoodbrands.co.uk/wp-content/uploads/2019/10/Euro-Food-Brands-Ltd-Modern-Slavery-Statement-2019-2020.pdf,43790,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,16989,25036
 ,https://www.eurogarages.com/pdf/Slavery.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7397,22952
 ,https://www.euro-gold.co.uk/anti-slavery-statement/,43784,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1068,NEW1069
@@ -5118,7 +5118,7 @@
 ,https://www.fluor.com/SiteCollectionDocuments/fluor-msa-statement.pdf,43781,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1130,NEW1131
 ,https://www.flybe.com/application/files/2815/7476/6494/Anti-Slavery_Statement_FY18-19.pdf,43508,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,22960,22961
 ,https://www.foremanhomes.co.uk/privacy-policy,43840,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,,,NEW1134,NEW1135
-,https://www.formula1.com/en/toolbar/modern-slavery-statement.html,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9312,"282,482,824,928,250"
+,https://www.formula1.com/en/toolbar/modern-slavery-statement.html,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9312,"28248,28249,28250"
 ,https://www.forthports.co.uk/corporate/modern-slavery-statement/,43781,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1142,NEW1143
 ,https://www.fortvale.com/about-us/modern-slavery-statement/,43781,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW1144,NEW1145
 ,https://www.foundationgroup.co.uk/index.php/modern-slavery,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1147,NEW1146
@@ -5133,7 +5133,7 @@
 ,https://gateway.mars.com/m/2c95c9e0ba07c3ce/Modern-Slavery-Statement-2018.pdf,43828,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1185,"NEW1186,NEW1187"
 ,https://gelder.co.uk/modern-slavery-statement/,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,8568,23206
 ,http://www.gfigroup.com/wp-content/uploads/2019/07/MSA-Statement-GFIBL-GFISL.pdf,43536,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1195,NEW1194
-,http://www.gftomlinson.co.uk/slavery-human-trafficking-statement/,43788,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8820,"2,325,023,251"
+,http://www.gftomlinson.co.uk/slavery-human-trafficking-statement/,43788,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8820,"23250,23251"
 ,https://www.glinwellplc.com/wp-content/uploads/2019/05/Modern-slavery-document.pdf,43788,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,10787,NEW1206
 ,https://gog-11615-s3.s3.eu-west-2.amazonaws.com/live/8215/6863/3000/Modern_Slavery_Act_Statement_2018_19.pdf,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7490,23458
 ,https://www.goldmansachs.com/investor-relations/corporate-governance/corporate-governance-documents/statement-on-modern-slavery-and-human-trafficking.pdf,43843,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1211,"NEW1212,NEW1213,NEW1214,NEW1215"
@@ -5142,7 +5142,7 @@
 ,http://www.graftonplc.com/~/media/Files/G/Grafton/documents/modern-slavery-policy-statement-2018-with-company-names.pdf,43784,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24437,"NEW1222,NEW1223"
 ,https://www.graham.co.uk/PositiveWebsite/media/Policies/Modern-Slavery-Act-2015-Anti-Slavery-and-Human-Trafficking-Policy-Statement-063.pdf,43597,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,24518,24519
 ,http://www.greencoat-ukwind.com/~/media/Files/G/GreenCoat-UKWind/documents/modern%20slavery%20statement%20UKW.pdf,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1230,NEW1231
-,https://www.greeneking.co.uk/modern-slavery-statement-2018/,43789,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7507,"22,967,229,682,297,100,000,000,000,000,000,000,000,000,000,000,000"
+,https://www.greeneking.co.uk/modern-slavery-statement-2018/,43789,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,7507,"22967,22968,22971,22972,22975,22985,22986,22988,22989,22990"
 ,https://www.greenergy.com/userfiles/media/greenergy2.cyb.co.uk/policies/greenergy_anti_slavery_policy_03.04.19.pdf,43536,No,Special Board Committee,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,21316,"NEW1246,NEW1249,NEW1248"
 ,https://greenfieldsireland.com/slavery.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22492,26004
 ,http://www.greentechplc.co.uk/wp-content/uploads/2019/03/Modern-Slavery-Statement-GT-12-03-19.pdf,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW1252,NEW1253
@@ -5153,7 +5153,7 @@
 ,http://www.grupoantolin.com/sites/default/files/modern_slavery_statement_2018_-_ga_irausa.pdf,43536,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1275,NEW1276
 ,https://www.guests.co.uk/modern-slavery-act-2015/,43805,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1297,NEW1296
 ,https://gvc-plc.com/corporate-responsibility/modern-slavery-statement/,43817,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1298,"NEW1299,NEW1300,NEW1301"
-,https://www.halliwelljones.co.uk/anti-slavery-and-human-trafficking-statement,43789,No,Finance Director,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,17544,"241,312,413,224,133"
+,https://www.halliwelljones.co.uk/anti-slavery-and-human-trafficking-statement,43789,No,Finance Director,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,17544,"24131,24132,24133"
 ,http://www.halsion.online/file/2018/11/modern-slavery-02112018102827.pdf,43803,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1308,NEW1309
 ,https://www.harratts.co.uk/modern-slavery-statement/,43803,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW1310,NEW1311
 ,https://www.harronhomes.com/wp-content/uploads/2019/04/Slavery-Human-Trafficking-Statement-2018.pdf,43789,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,,,17651,26177
@@ -5169,16 +5169,16 @@
 ,https://www.helstongarages.co.uk/site/modern-slavery-statement/,43803,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1341,NEW1342
 ,https://www.henderson-foodservice.com/slavery--human-trafficking-statement/,43839,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2017,24105,NEW1344
 ,https://henderson-group.com/csr/slavery-human-trafficking-statement/,43567,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2017,17435,NEW1345
-,http://www.henryboot.co.uk/media/1614/8b-modern-slavery-statement-version-3-march-2019.pdf,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,7543,"2,435,124,353"
+,http://www.henryboot.co.uk/media/1614/8b-modern-slavery-statement-version-3-march-2019.pdf,43790,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,7543,"24351,24353"
 ,https://www.herbertsmithfreehills.com/modern-slavery,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7545,"NEW1350,NEW1352"
 ,https://www.heritageautomotive.co.uk/pdf/modern-slavery-statement.pdf,43804,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1355,"NEW1353,NEW1354"
-,http://www.heygates.co.uk/sitefiles/uploads/documents/Modern%20Slavery%20Statement%202019.pdf,43791,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,18565,"244,282,443,024,432"
+,http://www.heygates.co.uk/sitefiles/uploads/documents/Modern%20Slavery%20Statement%202019.pdf,43791,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,18565,"24428,24430,24432"
 ,https://www.hibugroup.com/modern-slavery-act-transparency-state,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9451,"NEW1361,NEW1362"
 ,https://www.higgins-group.co.uk/modern-slavery-act-2015,43788,No,Chairman,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW1363,NEW1364
 ,https://highspeed1.co.uk/media/0ztnf2oy/modern-slavery-act-statement-for-the-year-ended-31-march-2019.pdf,43567,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7586,"NEW1365,NEW1366"
-,http://www.hikensingtonforumhotel.co.uk/modern-slavery-act-queensgate/,43784,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9931,"295,482,955,029,551"
+,http://www.hikensingtonforumhotel.co.uk/modern-slavery-act-queensgate/,43784,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9931,"29548,29550,29551"
 ,https://www.hill.co.uk/wp-content/uploads/2019/10/Hill-Modern-Slavery-2019-1.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24653,24655
-,https://www.hiscoxgroup.com/sites/group/files/documents/2019-04/hiscox-modern-slavery-statement.pdf,43789,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24452,"2,445,324,455"
+,https://www.hiscoxgroup.com/sites/group/files/documents/2019-04/hiscox-modern-slavery-statement.pdf,43789,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24452,"24453,24455"
 ,https://www.hl.co.uk/__data/assets/pdf_file/0009/11399832/Modern-Slavery-Act.pdf,43838,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7529,"NEW1379,NEW1380"
 ,https://www.hobbycraft.co.uk/modern-slavery,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,10212,NEW1382
 ,https://www.holdcroft.com/holdcroft%20anti-slavery%20human%20trafficking%20statement%202019.pdf,43804,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1387,"NEW1388,NEW1389,NEW1390"
@@ -5186,7 +5186,7 @@
 ,http://www.hoohing.co.uk/PBCPPlayer.asp?ID=2038872,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1409,NEW1410
 ,https://houlton.co.uk/resources/files/7bc6cae3444b198e666d15b7238289f7/houlton_anti_slavery_and_human_trafficking_statement_2018_rev1.pdf,43536,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,18618,24468
 ,https://howarthtimber.thirdlight.com/pf.tlx/UpMUAMUQzseDi,43567,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21237,24996
-,https://www.howdenjoinerygroupplc.com/archives/2018-Modern-Slavery-Statement.pdf,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22251,"2,564,725,648"
+,https://www.howdenjoinerygroupplc.com/archives/2018-Modern-Slavery-Statement.pdf,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22251,"25647,25648"
 ,https://www.hslchairs.com/modern-slavery-act/,43789,No,Chairman,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,21140,24919
 ,https://www.hsshiregroup.com/wp-content/uploads/2019/05/Modern-Slavery-Act-statement-FY18.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10442,"NEW1442,NEW1444"
 ,https://www.huntingplc.com/~/media/Files/H/Hunting-PLC-V2/documents/policies/hunting-plc-modern-slavery-act-statement-year-ending-31-december-2018.pdf,43688,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10737,NEW1446
@@ -5200,7 +5200,7 @@
 ,https://www.idoxgroup.com/media/2853/anti-slavery-and-human-trafficking-statement-2019.pdf,43788,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1471,NEW1472
 ,https://www.igt.com/-/media/7d13e6a0f5c14eb992ad305660e46e29.ashx,43790,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8967,NEW1473
 ,https://www.ikea.com/gb/en/files/pdf/5b/12/5b12117f/ikea-modern-slavery-statement.pdf,43790,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17020,"23968,NEW1477"
-,https://images.harrods.com/content/harrods_ms_fy19.pdf?icid=faqinstore_accordion_module-28_element-18_harrods-modern-slavery-act-statement-201819,43567,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21347,"251,512,515,225,153"
+,https://images.harrods.com/content/harrods_ms_fy19.pdf?icid=faqinstore_accordion_module-28_element-18_harrods-modern-slavery-act-statement-201819,43567,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21347,"25151,25152,25153"
 ,https://images.hertz.com/pdfs/HertzAntiSlaveryStatement.pdf,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9345,NEW1483
 ,https://imagination.com/sites/default/files/2019ModernSlaveryStatementV220190417.pdf,43567,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,7615,25205
 ,http://www.immediate.co.uk/modern-slavery-and-human-trafficking-statement/,43812,No,"Chairman, CEO, CFO",Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW1493,"NEW1491,NEW1492"
@@ -5211,7 +5211,7 @@
 ,https://www.ineos.com/information/anti-slavery-act/,43812,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1503,"NEW1504,NEW1505,NEW1506,NEW1508,NEW1509,NEW1510,NEW1511,NEW1507,NEW1512,NEW1513"
 ,https://www.innserveltd.co.uk/slavery,43790,No,Executive Committee,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10045,NEW1522
 ,http://www.interbevgroup.com/modern-slavery-policy.php,43597,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,17902,NEW1523
-,https://www.interserve.com/docs/default-source/about/policies/modern-slavery-statement.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,10477,"2,356,724,883,248,840,000,000,000,000,000,000,000,000"
+,https://www.interserve.com/docs/default-source/about/policies/modern-slavery-statement.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,10477,"23567,24883,24884,24885,24886,24887,24888,24889"
 ,https://www.investecassetmanagement.com/document/pdf/Investec-Asset-Management-Modern-Slavery-Act-Statement.pdf,43688,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21171,24936
 ,https://investor-prod-assets.s3.amazonaws.com/uploads/2019/06/Modern_Slavery_Statement_2019__GP_v1.0.docx.pdf,43597,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7678,25121
 ,https://www.iop.org/about/modern-slavery-act/page_69298.html,43833,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1544,"NEW1544,NEW1543"
@@ -5224,7 +5224,7 @@
 ,https://www.james-fisher.com/files/3115/6103/2730/James_Fisher_and_Sons_plc_Group_Modern_Slavery_Statement.pdf,43790,No,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9372,23357
 ,https://www.jlt.com/-/media/files/group/about/corporate-responsibility/signed-modern-slavery-statement---2018.ashx?la=en-gb&hash=C3566803E22DBEFCA4E059AB2CC17CEEF54114A9,43790,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10741,"NEW1593,NEW1591,NEW1592"
 ,https://www.johnsoncontrols.com/-/media/jci/suppliers/media-folder/corporate-responsibility/slavery_humantraffickingstatement_revmarch2019.pdf,43688,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,23212,23220
-,https://www.johnsoncontrols.com/-/media/jci/suppliers/media-folder/corporate-responsibility/slavery_humantraffickingstatement_revmarch2019.pdf?la=en&hash=58E46ED9C90435F348E85D3D653311996D9C6014,43812,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23213,"2,321,523,217"
+,https://www.johnsoncontrols.com/-/media/jci/suppliers/media-folder/corporate-responsibility/slavery_humantraffickingstatement_revmarch2019.pdf?la=en&hash=58E46ED9C90435F348E85D3D653311996D9C6014,43812,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23213,"23215,23217"
 ,https://www.jones-bros.com/wp-content/uploads/2019/03/JB-Policy-015-Anti-Slavery-Policy-1.pdf,43815,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW1607,NEW1608
 ,https://www.jpmorganchase.com/corporate/About-JPMC/document/modern-slavery-act-2018.pdf,43841,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1610,"NEW1611,NEW1609,NEW1612,NEW1613,NEW1614,NEW1615,NEW1616"
 ,https://jradam.co.uk/application/files/8615/5387/3788/Modern_Slavery__Human_Trafficking_policy.pdf,43812,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW1617,NEW1618
@@ -5259,14 +5259,14 @@
 ,https://liveapi.tceg.com/content/uploads/2019/11/TCEG-Modern-Slavery-Statement-2019.pdf,43824,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1715,NEW1716
 ,https://www.livewest.co.uk/modern-slavery-policy,43840,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW1717,NEW1718
 ,http://lloydsanimalfeeds.co.uk/wp-content/uploads/2019/07/Modern-slavery-Statement-.pdf,43830,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1723,NEW1724
-,https://www.lloydsbankinggroup.com/globalassets/documents/our-group/responsibility/policies-and-codes/2019-updates/modern-slavery--human-trafficking-statement-2018-final-published-feb-2019-tc.pdf,43790,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9118,"233,152,331,624,265"
+,https://www.lloydsbankinggroup.com/globalassets/documents/our-group/responsibility/policies-and-codes/2019-updates/modern-slavery--human-trafficking-statement-2018-final-published-feb-2019-tc.pdf,43790,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9118,"23315,23316,24265"
 ,https://www.lme.com/-/media/Files/About/Legal/LME-and-LME-Clear-Annual-Modern-Slavery-Statement.pdf?la=en-GB,43790,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10014,23466
 ,https://www.lockheedmartin.com/content/dam/lockheed-martin/uk/documents/who-we-are/LMUK_Modern_Day_Slavery_Act_Compliance_2019.pdf,43829,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1731,NEW1732
 ,https://www.logistics.dhl/content/dam/dhl/local/gb/core/documents/pdf/gb-core-modern-slavery-statement-19.pdf,43597,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,23819,"NEW1733,NEW1735,NEW1736"
 ,https://www.logistics.dhl/content/dam/dhl/local/gb/core/documents/pdf/gb-dhl-express-modern-slavery-statement-2019.pdf,43597,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,23823,NEW1737
 ,https://www.london-luton.co.uk/corporate/modern-slavery-statement,43688,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9076,"NEW1739,NEW1740,NEW1741"
 ,https://londonsquare.co.uk/transparency/transparency_statement,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,7751,25936
-,https://www.londonstockexchange.com/modern-slavery-statement.pdf,43628,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24327,"2,433,224,333"
+,https://www.londonstockexchange.com/modern-slavery-statement.pdf,43628,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24327,"24332,24333"
 ,https://www.lqgroup.org.uk/_assets/files/view/83235e81-d0d9-45f3-92da-0442d45776a2/,43657,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9645,"NEW1759,NEW1761,NEW1762,NEW1758"
 ,https://www.lseg.com/sites/default/files/content/documents/CR_documents/2019/LSEG%20Modern%20Slavery%20Act%20Statement%20for%20YE%2031%20December%202018.pdf,43790,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8599,"24329,NEW1763"
 ,https://lucygroup-production-assets.s3.eu-west-2.amazonaws.com/2019/06/Modern-Slavery-Statement-2817_001.pdf,43688,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17659,24159
@@ -5277,7 +5277,7 @@
 ,https://www.mallinckrodt.com/globalassets/documents/mallinckrodt-uk-modern-slavery-act-disclosure-2019.pdf,43840,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,25857,NEW1784
 ,https://www.mandco.com/corporate/modern-slavery-act/modern-slavery-act/Modern-Slavery-Act.html,43786,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,17740,NEW1789
 ,https://www.marshalls.co.uk/documents/policies/marshalls-modern-slavery-statement-2019.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,7781,24805
-,https://www.mastercard.us/en-us/about-mastercard/corp-responsibility/social-sustainability/mastercard-modern-slavery-and-human-trafficking-statement.html,43828,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,26199,"2,620,026,201"
+,https://www.mastercard.us/en-us/about-mastercard/corp-responsibility/social-sustainability/mastercard-modern-slavery-and-human-trafficking-statement.html,43828,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,26199,"26200,26201"
 ,https://www.matfoundrygroup.com/res/EURAC%20-%20Modern%20Slavery%20Statement%202018%20Final.pdf,43780,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1805,NEW1806
 ,https://www.mawdsleys.co.uk/uploads/images/Modern-Slavery-Act-Statement.pdf,43780,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7789,NEW1812
 ,https://www.maximusuk.co.uk/sites/default/files/Documents/modern-slavery-statement.pdf,43791,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,24177,24178
@@ -5286,14 +5286,14 @@
 ,https://www.mcsaatchiplc.com/legal/modern-slavery,43786,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,18638,NEW1823
 ,http://mcs-ltd.com/wp-content/uploads/2018/07/Modern-Slavery-and-Human-Trafficking-Statement-01-18.pdf,43827,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2016,2016,NEW1825,NEW1826
 ,https://meadowvalefoods.co.uk/wp-content/uploads/2019/07/modern-slavery-statement.pdf,43597,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1827,NEW1828
-,https://media.audleytravel.com/-/media/files/about-us/responsible-travel/signedmodernslaveryactstatement_2019.pdf?la=en,43794,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,28288,"2,854,228,569"
+,https://media.audleytravel.com/-/media/files/about-us/responsible-travel/signedmodernslaveryactstatement_2019.pdf?la=en,43794,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,28288,"28542,28569"
 ,http://media.genre.com/documents/Anti-slavery+April+2019.pdf,43784,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1832,NEW1833
 ,https://www.mercedes-benz.co.uk/,43780,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,7814,18996
 ,https://www.merckgroup.com/company/responsibility/en/Merck-UK-Modern-Slavery-Act-Statement.pdf,43827,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1841,"NEW1842,NEW1843"
 ,https://www.merckgroup.com/uk-en/Merck_UKMS%20Statement%202019.pdf,43795,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1844,NEW1845
 ,http://www.mhivestasoffshore.com/wp-content/uploads/2019/12/MVOW-Modern-Slavery-Act-Statement-2019.pdf,43826,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW1857,NEW1858
 ,https://www.michaellonsdale.com/wp-content/uploads/2019/06/07-Michael-Lonsdale-Group-Slavery-and-Human-Trafficking-Policy-Rev-3-Feb-19.pdf,43689,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,21426,25264
-,https://www.midasgroup.co.uk/files/Modern%20Slavery%20Statement%202019.pdf,43839,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7828,"2,450,124,505"
+,https://www.midasgroup.co.uk/files/Modern%20Slavery%20Statement%202019.pdf,43839,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7828,"24501,24505"
 ,http://www.midwichgroupplc.com/media/1199/201906-midwich-group-plc-slavery-and-human-trafficking-statement-final-002.pdf,43826,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW1864,NEW1865
 ,https://www.miki.co.uk/slavery_statement,43780,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,8777,NEW1866
 ,http://www.miromagroup.com/modern-slavery-statement/,43826,No,CEO,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW1870,NEW1871
@@ -5332,7 +5332,7 @@
 ,https://www.nfumutual.co.uk/legal-information/slavery-and-human-trafficking-statement/,43825,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2021,NEW2022
 ,https://www.nice.com/corporate-responsibility/slavery-and-human-trafficking-statement/,43817,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW2027,NEW2028
 ,https://www.norcros.com/files/1615/6095/9531/NXR_Modern_Slavery_Act_Statement_June_2019.pdf,43782,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7924,NEW2035
-,https://www.northerngasnetworks.co.uk/wp-content/uploads/2019/04/Modern-Slavery-Act-Transparency-Statement-2019.docx.pdf,43782,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7932,"2,445,724,459"
+,https://www.northerngasnetworks.co.uk/wp-content/uploads/2019/04/Modern-Slavery-Act-Transparency-Statement-2019.docx.pdf,43782,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7932,"24457,24459"
 ,https://www.northernpowergrid.com/downloads/4871,43782,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8763,"23245,NEW2041,NEW2043"
 ,https://www.nskeurope.com/en/modern-slavery-statement.html,43782,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,7946,"NEW2052,NEW2054"
 ,https://www.nwffuels.co.uk/modern-slavery-statement/,43783,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2056,NEW2055
@@ -5367,7 +5367,7 @@
 ,https://www.pfizer.co.uk/sites/g/files/g10052056/f/201905/2019_California_Transparency_UK_MSA_15JAN2019%20%28002%29.pdf,43817,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23756,"NEW2179,NEW2180,NEW2178"
 ,https://www.pgim.com/wps/wcm/connect/fa78c0ce-3b13-4920-a484-809ecc214f7c/Modern_Slavery_Act_Statement.pdf?MOD=AJPERES,43769,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2182,NEW2183
 ,https://www.phillips66.co.uk/EN/Regulatory/Pages/Modern%20Slavery%20Act%20Disclosure.pdf,43783,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10959,23867
-,https://www.phoenixnaturalgas.com/assets/general/Phoenix-Group-Modern-Slavery-Transparency-Statement-YE-31-12-18.pdf,43628,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24260,"2,426,124,262"
+,https://www.phoenixnaturalgas.com/assets/general/Phoenix-Group-Modern-Slavery-Transparency-Statement-YE-31-12-18.pdf,43628,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24260,"24261,24262"
 ,https://www.photobox.co.uk/statement-human-trafficking-slavery,43816,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2191,NEW2192
 ,https://pinerivercapital.com/PineRiverDocument/Download/93,43816,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2193,NEW2194
 ,https://www.pinnaclegroup.co.uk/wp-content/uploads/2019/11/Modern-Slavery-Transparency-Statement-2019.pdf,43750,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,22567,26024
@@ -5403,12 +5403,12 @@
 ,https://www.ricoh-europe.com/media/FY19%20Modern%20Slavery%20Act%20Statement%20(Final%20Signed%20-%2026.09.19)_tcm100-13723.pdf,43786,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9805,"23494,NEW2329"
 ,http://www.rightacres.co.uk/download/i/mark_dl/u/4012212792/4635918687/Slavery%20statement%20-%202019.doc,43784,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2330,NEW2331
 ,https://www.ringways.co.uk/modern-slavery-act,43819,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2332,NEW2333
-,https://www.riotinto.com/documents/RT_Slavery_and_human_trafficking_statement_2018.pdf,43787,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8103,"2,703,227,033,270,340,000,000,000"
+,https://www.riotinto.com/documents/RT_Slavery_and_human_trafficking_statement_2018.pdf,43787,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8103,"27032,27033,27034,27035,27036"
 ,https://www.rittal.com/uk-en/content/en/impressum/impressum.jsp,43819,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW2341,NEW2340
 ,https://riverandmercantile.com/Asp/uploadedFiles/file/About/RandM_Modern_Slavery_Statement.pdf,43840,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8104,NEW2343
 ,https://www.rnib.org.uk/statement-modern-slavery-2018,43839,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,17578,NEW2345
 ,https://www.robertson.co.uk/anti-slavery-statement,43819,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW2346,"NEW2347,NEW2348,NEW2349,NEW2350,NEW2351,NEW2352,NEW2354,NEW2353"
-,https://www.roche.co.uk/content/dam/rochexx/roche-co-uk/downloads/Modern_Slavery_Act_2019.pdf,43787,No,General Managers,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9739,"2,342,623,427"
+,https://www.roche.co.uk/content/dam/rochexx/roche-co-uk/downloads/Modern_Slavery_Act_2019.pdf,43787,No,General Managers,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9739,"23426,23427"
 ,https://www.ronly.com/wp-content/uploads/Ronly-2018-Anti-Slavery-Statement.pdf,43784,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2358,NEW2359
 ,https://rosebuilders.co.uk/modern_slavery_policy/,43781,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,18275,24252
 ,https://www.rothesaylife.com/modern-slavery-statement/,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9036,NEW2363
@@ -5417,7 +5417,7 @@
 ,https://www.rsk.co.uk/images/technical-library/brochures/RSK%20Group%20Modern%20Slavery%20Statement.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,17059,NEW2373
 ,https://www.rsmuk.com/slavery-and-human-trafficking,43786,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,9624,"NEW2375,NEW2376,NEW2378,NEW2379"
 ,https://www.rubix-group.com/slavery/,43767,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2380,NEW2381
-,https://www.rullion.co.uk/modern-slavery-statement-2019/,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8128,"230,512,305,232,774"
+,https://www.rullion.co.uk/modern-slavery-statement-2019/,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8128,"23051,23052,32774"
 ,https://www.rybrook.co.uk/wp-content/uploads/2019/05/Rybrook-Modern-Slavery-Statement-2019.pdf,43787,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17368,NEW2386
 ,https://www.ryman.co.uk/ethical-trading/,43822,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2391,NEW2390
 ,https://s23.q4cdn.com/956522167/files/doc_downloads/act/plc-(2018.12.31)-Slavery-and-Human-Trafficking-Statement.pdf,43795,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2392,"NEW2393,NEW2394,NEW2395"
@@ -5427,20 +5427,20 @@
 ,https://s3-eu-west-1.amazonaws.com/pdf.utilitywarehouse.co.uk/telecom-plus-plc-modern-slavery-statement-fy2019.pdf,43536,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,27873,27874
 ,https://s3-eu-west-1.amazonaws.com/sancarlo/wp-content/uploads/2019/04/15102802/Modern-Slavery-Statement-FINAL-March-2019.pdf,43840,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21244,25007
 ,http://s7d2.scene7.com/is/content/Caterpillar/CM20180625-31685-62307,43798,Not explicit,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2421,"NEW2422,NEW2423,NEW2424"
-,https://www.saga.co.uk/modern-slavery-statement,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9490,"210,532,841,628,427"
+,https://www.saga.co.uk/modern-slavery-statement,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9490,"21053,28416,28427"
 ,https://www.saica.com/wp-content/uploads/2019/05/Modern-Slavery-Act-Statement-2018.pdf,43786,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17062,"NEW2429,NEW2431"
 ,https://www.sainsburysbank.co.uk/~/media/files/pdf/modern-slavery-statement.pdf,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,9013,NEW2432
 ,http://salisburygroup.com/Modern_Slavery_and_Human_Trafficking_Statement,43822,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW2438,NEW2439
 ,https://www.salvationarmy.org.uk/modern-slavery-statement,43822,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2440,"NEW2441,NEW2442"
 ,http://www.sandalbmw.com/files/mdss.pdf,43769,No,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2443,NEW2444
-,https://www.sandersonplc.com/policies/modern-slavery-statement.pdf,43811,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,24970,"3,036,830,373"
+,https://www.sandersonplc.com/policies/modern-slavery-statement.pdf,43811,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,24970,"30368,30373"
 ,https://www.sandown-group.co.uk/modern-slavery-act.aspx,43823,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2448,NEW2449
-,https://www.sanofi.co.uk/-/media/project/one-sanofi-web/websites/europe/sanofi-uk/home/sanofi-uk-modern-slavery-act-statement20190408final-for-website.pdf,43794,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,25140,"2,514,225,143"
-,https://www.santander.co.uk/csdlvlr/BlobServer?blobtable=MungoBlobs&blobkey=id&blobcol=urldata&blobheader=application%2Fpdf&blobheadervalue1=inline%3Bfilename%3DSlavery+and+Human+Trafficking+Statement+FY18+-+FOR+PUBLICATION.pdf&blobwhere=1314026294930&blobheadername1=Content-Disposition,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,9866,"268,262,701,627,017,000,000,000,000,000"
+,https://www.sanofi.co.uk/-/media/project/one-sanofi-web/websites/europe/sanofi-uk/home/sanofi-uk-modern-slavery-act-statement20190408final-for-website.pdf,43794,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,25140,"25142,25143"
+,https://www.santander.co.uk/csdlvlr/BlobServer?blobtable=MungoBlobs&blobkey=id&blobcol=urldata&blobheader=application%2Fpdf&blobheadervalue1=inline%3Bfilename%3DSlavery+and+Human+Trafficking+Statement+FY18+-+FOR+PUBLICATION.pdf&blobwhere=1314026294930&blobheadername1=Content-Disposition,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,9866,"26826,27016,27017,27019,27020,27021"
 ,http://www.sarasinandpartners.com/docs/default-source/regulatory-and-policies/anti-modern-slavery,43784,No,Executive Committee,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2460,"NEW2461,NEW2462"
 ,https://www.scapa.com/Content/docs/footer/UK-Modern-Slavery-Statement-2019.pdf,43791,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8145,25995
 ,https://www.scottbader.com/wp-content/uploads/Modern-Slavery-Act-2015-Statement-For-Financial-Year-2018-2019.pdf,43787,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10341,"28004,NEW2474"
-,https://www.scottdunn.com/about/legalities/modern-slavery-act,43791,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22399,"2,594,825,949"
+,https://www.scottdunn.com/about/legalities/modern-slavery-act,43791,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22399,"25948,25949"
 ,http://www.seajacks.com/wp-content/uploads/2019/04/Modern-Slavery-Statement-27-March-2019-1.pdf,43796,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,8160,"NEW2490,NEW2491,NEW2492,NEW2493"
 ,https://www.sebdengroup.com/wp-content/uploads/2019/09/modern_slavery_group_2018_2019.pdf,43750,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2495,NEW2496
 ,https://www.seniorplc.com/~/media/Files/S/Senior-PLC/documents/modern_slavery_act_statement_2018_website.pdf,43787,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8643,23225
@@ -5471,23 +5471,23 @@
 ,https://www.southamptonfc.com/club/-/media/727722f42faa40409142e3b43f22d611.ashx,43812,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,9925,18365
 ,https://www.spar.co.uk/explore/explore/modern-slavery-statement,43788,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,21432,NEW2610
 ,http://www.sparrowsgroup.com/images/sparrows/pdfs/misc/Sparrows_Group_Modern_Slavery_Statement.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,10048,"NEW2611,NEW2612,NEW2613,NEW2615"
-,https://www.specsavers.co.uk/news-and-information/modern-slavery-act,43832,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,25871,"2,587,225,873,258,740,000,000,000"
+,https://www.specsavers.co.uk/news-and-information/modern-slavery-act,43832,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,25871,"25872,25873,25874,25875,25877"
 ,https://www.spectris.com/~/media/Files/S/Spectris/documents/modern-slavery-and-human-trafficking-statement-2019.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,8225,"NEW2623,NEW2622"
 ,https://www.spglobal.com/en/who-we-are/corporate-responsibility/spgi-modern-slavery-act-statement-2018.pdf,43822,Yes,,No,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2628,NEW2629
 ,https://www.ssctech.com/Portals/0/Documents/pdf-assets/SSC-DST-Modern-Slavery-Act.pdf,43799,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,27804,NEW2633
 ,https://sse.com/media/588855/Modern-Slavery-2018.pdf,43508,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW2635,NEW2634
 ,https://sse.com/media/623553/Modern-Slavery-Report-2019.pdf,43827,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2637,"NEW2639,NEW2640,NEW2641,NEW2642,NEW2643,NEW2644,NEW2645,NEW2646,NEW2647,NEW2648,NEW2649,NEW2650,NEW2636,NEW2638"
-,https://www.stagecoach.com/~/media/Files/S/Stagecoach-Group/Attachments/modern-slavery-act-transparency-statements/modern-slavery-act-transparency-statement-2019.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8247,"230,782,307,923,081,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000"
+,https://www.stagecoach.com/~/media/Files/S/Stagecoach-Group/Attachments/modern-slavery-act-transparency-statements/modern-slavery-act-transparency-statement-2019.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8247,"23078,23079,23081,23082,23083,23084,23085,23086,23088,23089,23090,23092,23093,23095,23096,23099,23100,23101"
 ,https://staging.rnwooler.co.uk/wp-content/uploads/2019/05/modern_slavery_human_traffickin.pdf,43816,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2670,NEW2671
 ,https://www.stannah.com/wp-content/uploads/Modern-Slavery-Document-08.08.19.pdf,43833,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW2673,NEW2672
 ,http://www.statestreet.com/content/dam/statestreet/documents/utility/UK/ModernSlaveryActStatement2018.pdf,43812,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,27774,27776
 ,https://static.conocophillips.com/files/resources/modern-slavery-position-may-2019.pdf,43797,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8960,24605
-,https://static.macquarie.com/dafiles/Internet/mgl/global/shared/about/disclosures/docs/modern-slavery-act-transparency-statement-2019.pdf?v=3,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7505,"253,262,532,825,330,000,000,000,000,000"
+,https://static.macquarie.com/dafiles/Internet/mgl/global/shared/about/disclosures/docs/modern-slavery-act-transparency-statement-2019.pdf?v=3,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7505,"25326,25328,25330,25337,25340,25348"
 ,https://static1.squarespace.com/static/54aa9a76e4b040ef97e6b576/t/5cd4216de4966b1cef077814/1557406070197/policy-050419.pdf,43830,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW2685,NEW2686
 ,https://static1.squarespace.com/static/5bd2f525a09a7e21dbcb5129/t/5dc942213287191960b6bc6f/1573470753248/Modern+Slavery+Policy+Statement.pdf,43804,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2689,NEW2690
 ,https://www.steepergroup.com/SteeperGroup/media/SteeperGroupMedia/Additional%20Downloads/2019-Steeper-Group-modern-slavery-and-human-trafficking-annual-statement.pdf?ext=.pdf,43805,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW2693,NEW2694
 ,https://www.stenaline.co.uk/-/media/Files/irish-seas/pdf/legal/Modern_Slavery_Statement.pdf,43833,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2695,NEW2696
-,https://www.stmodwen.co.uk/wp-content/uploads/2019/04/modern-slavery-act-transparency-statement-for-financial-year-2017-2018.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8961,"2,514,725,148"
+,https://www.stmodwen.co.uk/wp-content/uploads/2019/04/modern-slavery-act-transparency-statement-for-financial-year-2017-2018.pdf,43788,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8961,"25147,25148"
 ,https://strata.co.uk/modern-slavery-and-human-trafficking-statement/,43833,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2702,NEW2703
 ,https://www.stratstoneleedsmini.co.uk/modern-slavery-statement/,43833,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24256,"NEW2704,NEW2705"
 ,https://www.subsea7.com/content/dam/subsea7-corporate2018/Documents/Code_of_Conduct/SLAVERY%20AND%20HUMAN%20TRAFFICKING%20STATEMENT%20FOR%20SUBSEA%207%2031%20Dec%202018.pdf,43833,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,25443,"25444,NEW2707,NEW2708,NEW2709,NEW2710,NEW2712"
@@ -5498,24 +5498,24 @@
 ,https://www.swanseacity.com/sites/default/files/2019-11/modern_slavery_statement_2019-2020.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,10625,NEW2727
 ,http://www.swspar.com/supplier/supplier-slavery-statement.php,43688,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,17470,NEW2728
 ,https://www.synthomer.com/fileadmin/files/homepage/Synthomer_Modern_Slavery_Statement_2018.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9539,NEW2730
-,https://www.sytner.co.uk/modern-slavery-statement/,43789,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,21015,"262,152,621,626,217,000,000,000,000,000"
+,https://www.sytner.co.uk/modern-slavery-statement/,43789,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,21015,"26215,26216,26217,26219,26220,26221"
 ,https://www.sytnercoventrybmw.co.uk/media/307459/modern-slavery-act-statement-incl-entities-2019-compressed.pdf,43833,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,26218,26223
 ,https://www.tanvictyres.co.uk/slavery/,43769,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2741,NEW2742
 ,http://www.tataglobalbeverages.com/docs/default-source/default-document-library/modern-slavery-statement-2019-signed.pdf?sfvrsn=2,43786,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,10424,NEW2744
 ,https://www.tateandlyle.com/sites/default/files/2019-05/Modern%20Slavery%20Act%20Statement%20FY19.pdf,43812,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,8299,NEW2745
 ,https://www.taylormaxwell.co.uk/uploads/heros/Taylor-Maxwell-Co-Ltd-Slavery-Statement-31-March-2019.pdf,43782,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2747,NEW2748
 ,https://www.tbrown.com/modern-slavery-act/,43796,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,21427,25265
-,https://www.tcifund.com/files/Modern%20Slavery%20Statement.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8304,"100,272,770,327,705"
+,https://www.tcifund.com/files/Modern%20Slavery%20Statement.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8304,"10027,27703,27705"
 ,https://www.technip.com/-/media/technipfmc/Downloads/ethics-and-conduct/modern-slavery-statement-2018.pdf?la=en&hash=C6FAED14EAE6C3BAEA86D45857F172090EFCED98,43835,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,25858,NEW2757
 ,https://www.technipfmc.com/-/media/technipfmc/Downloads/ethics-and-conduct/modern-slavery-statement-2018.pdf?la=en&hash=C6FAED14EAE6C3BAEA86D45857F172090EFCED98,43786,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22276,"NEW2759,NEW2760,NEW2762"
 ,https://www.teekay.com/wp-content/uploads/2019/05/Modern-Slavery-Act-statement-2019-signed-by-AGS.pdf,43843,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2763,"NEW2764,NEW2765"
 ,https://www.teledyne.com/Documents/2019TransparencyinSupplyChainUK2015SlaveryActDisclosure.pdf,43835,No,Nominating and Compliance Committee,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW2766,NEW2767
 ,https://www.tenetgroup.co.uk/legals.html,43789,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9495,NEW2775
 ,http://www.tesla.co.uk/ewExternalFiles/Modern%20Slavery%20Statement%20-%20Storrington%20Equityco%20-%2008-11-19.pdf,43811,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2785,NEW2786
-,http://test.ianmosey.com/wp-content/uploads/2019/03/FinalModernSlaveryStatement_Mar19.pdf,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,27102,"2,718,727,188"
-,https://www.thalesgroup.com/en/global/presence/europe/united-kingdom/sustainability-uk/modern-slavery-act-statement,43815,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9367,"3,031,730,318"
-,https://www.thameswater.co.uk/-/media/Site-Content/Thames-Water/Legal/modern-slavery-act.pdf,43789,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8315,"2,311,025,537"
-,https://www.thatcherscider.co.uk/modern-slavery-statement/,43839,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10227,"2,349,223,493"
+,http://test.ianmosey.com/wp-content/uploads/2019/03/FinalModernSlaveryStatement_Mar19.pdf,43567,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,27102,"27187,27188"
+,https://www.thalesgroup.com/en/global/presence/europe/united-kingdom/sustainability-uk/modern-slavery-act-statement,43815,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9367,"30317,30318"
+,https://www.thameswater.co.uk/-/media/Site-Content/Thames-Water/Legal/modern-slavery-act.pdf,43789,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8315,"23110,25537"
+,https://www.thatcherscider.co.uk/modern-slavery-statement/,43839,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,10227,"23492,23493"
 ,https://www.thebarcodewarehouse.co.uk/Documents/BCW/Modern%20Slavery%20Statement%20Nov%202019.pdf,43833,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW2801,NEW2802
 ,https://www.thebelfieldgroup.com/wp-content/uploads/2019/02/Belfield-Group-Modern-Day-Slavery-Statement-2019.pdf,43719,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,7056,10277
 ,https://www.theclancygroup.co.uk/wp-content/uploads/2019/08/07.19-Modern-Slavery-Statment.pdf,43782,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2805,NEW2806
@@ -5530,7 +5530,7 @@
 ,https://www.timico.com/wp-content/uploads/2019/04/modern-slavery-statement.pdf,43815,No,Finance Director,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17918,NEW2847
 ,https://www.tmhcc.com/-/media/RoW/Documents/Legal-Info/Modern-Slavery-and-Human-Trafficking-Statement.pdf,43838,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2848,NEW2849
 ,https://togethermoney.com/company-pages/company-policies/modern-slavery-act-statement/,43840,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2850,NEW2851
-,http://www.tokiomarinekiln.com/responsibility/policies/modern-slavery-act/,43815,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,23511,"2,351,323,514"
+,http://www.tokiomarinekiln.com/responsibility/policies/modern-slavery-act/,43815,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,23511,"23513,23514"
 ,https://www.tottenhamhotspur.com/the-club/anti-slavery-and-human-trafficking-statement/,43786,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,8336,"NEW2861,NEW2862"
 ,https://www.towertransit.co.uk/modern-slavery-policy/,43688,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,17764,NEW2866
 ,https://www.tpllp.com/wp-content/themes/tp/img/modern-slavery-act-statement.pdf,43832,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2869,"NEW2870,NEW2871"
@@ -5545,11 +5545,11 @@
 ,https://www.turnerandtownsend.com/media/4693/modern-slavery-act-2019-final.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,8354,"25270,25271,NEW2901"
 ,https://www.uk.issworld.com/-/media/issworld/uk/Files/CSR%20Policies%20and%20documents/ISS%20UK%20Anti%20Slavery%20and%20Human%20Trafficking%20Statement%202018.pdf,43789,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,25242,25243
 ,https://uk.kuehne-nagel.com/fileadmin/country_page_structure/WE/UK/_New_Layout_/Homepage/Kuehne___Nagel_2019_20190404155342974.pdf,43628,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,9223,"NEW2911,NEW2912,NEW2914"
-,https://uk.lush.com/article/2018-statement-combating-modern-slavery,43628,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,26609,"266,102,661,132,746"
+,https://uk.lush.com/article/2018-statement-combating-modern-slavery,43628,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,26609,"26610,26611,32746"
 ,https://www.ukpowernetworks.co.uk/-/media/files/footer-nav-documents/slavery-and-human-trafficking-statement-31-07-19.ashx,43628,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW2921,"NEW2922,NEW2923,NEW2926,NEW2927,NEW2928,NEW2924,NEW2925"
 ,https://unitedkingdom.chevron.com/-/media/united-kingdom/about/documents/UK-modern-slavery-act-statement-2019.pdf,43797,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,30647,30648
 ,https://unitedlearning.org.uk/Portals/0/ModernSlaveryAct2019.pdf?ver=2019-02-18-114542-810,43829,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,NEW2933,"NEW2934,NEW2935"
-,https://unitedliving.co.uk/perch/resources/3250-anti-slavery-and-human-trafficking-statement-1-april-2019-1.pdf,43816,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17610,"2,414,628,243"
+,https://unitedliving.co.uk/perch/resources/3250-anti-slavery-and-human-trafficking-statement-1-april-2019-1.pdf,43816,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,17610,"24146,28243"
 ,https://www.ups.com/assets/resources/media/en_GB/modern-slavery-statement.pdf,43780,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23865,NEW2942
 ,https://urenco.com/cdn/uploads/supporting-files/MSA_Transparency_Statement_SIGNED_110719.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8895,"NEW2944,NEW2946,NEW2947"
 ,https://www.used-cars-stoke.co.uk/wp-content/uploads/2019/06/Modern-Slavery-Statement.pdf,43816,Not explicit,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,NEW2948,NEW2949
@@ -5564,7 +5564,7 @@
 ,https://www.village-hotels.co.uk/media/8546/modern-slavery-statement-final-signed-26-june-2019.pdf,43840,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW2989,NEW2990
 ,https://www.vinciconstruction.co.uk/downloads/modern-slavery-and-human-trafficking-statement.pdf,43827,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,8416,NEW2992
 ,https://vindisgroup.com/storage/app/media/uploaded-files/Vindis%20Group%20Ltd%20Anti-Slavery%20and%20Human%20Trafficking%20Policy%20Statement.pdf,43750,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,NEW2993,"NEW2994,NEW2995,NEW2997,NEW2996"
-,https://www.virgin.com/download/file/fid/1867496,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,18865,"2,464,424,645"
+,https://www.virgin.com/download/file/fid/1867496,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,18865,"24644,24645"
 ,https://vitacress.s3.amazonaws.com/6%20Vitacress%20Slavery%20and%20Human%20Trafficking%20Statement%20FINAL%202018.pdf,43827,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,24690,24691
 ,https://www.vitality.co.uk/legal/,43816,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,22197,25593
 ,https://www.vitecgroup.com/media/2685/slavery-human-trafficking-statement-11dec2018.pdf,43829,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,8896,NEW3019
@@ -5574,7 +5574,7 @@
 ,https://www.voyagecare.com/about-voyage-care/modern-slavery-statement/,43816,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,26900,NEW3039
 ,https://www.walgreensbootsalliance.com/modern-slavery-and-human-trafficking-statement/,43795,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,23772,"23773,23775,23776,NEW3049,NEW3042,NEW3047,NEW3048"
 ,https://www.wateradditives.com/files/assets/Modern-Slavery-and-Human-Trafficking-Statement-YE-2018.pdf,43810,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW3050,NEW3051
-,https://www.wates.co.uk/wp-content/uploads/2019/09/Gov-700-Modern-Slavery-and-Human-Trafficking-Statement.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9905,"23,453,234,552,345,600,000"
+,https://www.wates.co.uk/wp-content/uploads/2019/09/Gov-700-Modern-Slavery-and-Human-Trafficking-Statement.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2019,9905,"23453,23455,23456,23457"
 ,https://www.wba.co.uk/club/club-policies/anti-slavery-policy/,43826,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW3057,"NEW3058,NEW3059"
 ,https://www.wedge-galv.co.uk/slavery-statement,43794,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,NEW3062,NEW3063
 ,https://www.westconcomstor.com/content/dam/wcgcom/Global/CorpSite/Legal/Westcon%20anti-slavery%20and%20human%20trafficking%20statement.pdf,43826,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,,,NEW3069,NEW3070
@@ -5585,14 +5585,14 @@
 ,https://www.williamgrant.com/modern_slavery.php,43794,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,22475,"25984,NEW3095,NEW3094"
 ,https://www.willmottdixon.co.uk/asset/13839/download,43657,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17378,"23390,23391,NEW3096,NEW3100"
 ,https://www.wimbledon.com/en_GB/about_wimbledon/modern_slavery_act_2015.html,43789,Not explicit,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,17780,NEW3102
-,https://www.wingyip.com/modern-slavery-act/,43816,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,17680,"2,416,224,163"
+,https://www.wingyip.com/modern-slavery-act/,43816,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2019,2020,17680,"24162,24163"
 ,https://www.winton.com/winton-transparency-statement-on-modern-slavery,43825,No,Director,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW3106,NEW3107
 ,https://www.wollastonbmw.co.uk/media/302477/modern-slavery-statement-2.pdf,43840,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2017,2017,NEW3108,NEW3109
 ,https://www.woodlandgroup.com/media/1530/modern-slavery-and-human-trafficking-statement.pdf,43797,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,22415,NEW3110
 ,https://www.woodplc.com/__data/assets/pdf_file/0021/50646/COP-POL-100001-External.pdf,43812,Not explicit,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2019,23264,"23267,23271,NEW3112,NEW3113,NEW3117,NEW3118"
 ,https://www.wpp.com/-/media/project/wpp/files/sustainability/modern_slavery_statement_signed_2018.pdf,43791,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,30593,"30595,NEW3119"
 ,https://www.xerox.com/downloads/dl/gbr/en/m/UK_Modern_Slavery_Act_Transparency_Statement.pdf,43824,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,25996,"25997,NEW3126"
-,https://xpodotcom.azureedge.net/xpo/files/s12/XPO_UK_Modern_Slavery_Statement_01.01.2018_-_31.12.2018.pdf,43824,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23902,"2,390,323,904"
-,https://www.zeiss.co.uk/content/dam/Corporate/UK/Downloads/PDF/modern_slavery_2018.pdf,43798,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,24030,"2,403,125,048"
+,https://xpodotcom.azureedge.net/xpo/files/s12/XPO_UK_Modern_Slavery_Statement_01.01.2018_-_31.12.2018.pdf,43824,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,23902,"23903,23904"
+,https://www.zeiss.co.uk/content/dam/Corporate/UK/Downloads/PDF/modern_slavery_2018.pdf,43798,Yes,,Yes,,FALSE,,,f,6,t,carrier@business-humanrights.org,f,2017,2018,24030,"24031,25048"
 ,https://www.zoopla.co.uk/slavery-statement/,43657,Yes,,No,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,17600,24145
 ,https://www.zurich.co.uk/en/about-us/corporate-responsibility/marketplace/modern-slavery-act,43776,Yes,,Yes,,TRUE,,,f,6,t,carrier@business-humanrights.org,f,2018,2018,NEW3138,"NEW3139,NEW3140,NEW3141,NEW3137"

--- a/lib/tasks/import_audit_data.rake
+++ b/lib/tasks/import_audit_data.rake
@@ -7,6 +7,9 @@ namespace :import_audit_data do
     company_columns = companies.shift
     statements = CSV.read('lib/tasks/fixtures/audit/statements.csv')
     statement_columns = statements.shift
+    rows = 0
+    count = 0
+    invalid = 0
 
     statements.each do |s|
       statement_params = {}.with_indifferent_access
@@ -14,61 +17,94 @@ namespace :import_audit_data do
         statement_params[key] = s[i]
       end
       params = statement_params.select { |key, _value| Statement.column_names.include?(key) }
-      company_id = params[:company_id].to_i
+
+      lead_company = nil
+      additional_companies = []
+      lead_company_id = params[:company_id]
+      statement_company_ids = [lead_company_id, *statement_params[:related_companies]&.split(',')].uniq.compact
 
       ActiveRecord::Base.transaction do
-        # create a new company for this statement to belong to, find it's information in `companies`
-        if params[:company_id] =~ /^NEW/
-          imported_company_data = companies.find { |c| c[0] == params[:company_id] }
-          company_params = {}.with_indifferent_access
-          company_columns.each_with_index do |key, i|
-            company_params[key] = format(imported_company_data[i], i) unless i.zero?
-            # ^ do not use the supplied :id, which is in the first column
-          end
-          company = Company.find_by(company_number: company_params[:company_number].rjust(8, '0'))
-          company ||= Company.find_by(name: company_params[:name])
-          company ||= Company.new(company_params)
-          if company.new_record?
-            if company.valid?
-              # puts "would save new company: #{company.name}"
-              company.save
-            else
-              puts "Invalid new company:   #{company.inspect}"
-              puts company.errors.inspect
+        # create all new companies for this statement to belong to, find company information in `companies`
+        statement_company_ids.each_with_index do |company_id, index|
+          if company_id =~ /^NEW/
+            imported_company_data = companies.find { |c| c[0] == company_id }
+            company_params = {}.with_indifferent_access
+            company_columns.each_with_index do |key, i|
+              company_params[key] = format(imported_company_data[i], i) unless i.zero?
+              # ^ do not use the supplied :id, which is in the first column
             end
+            company = Company.find_by(company_number: company_params[:company_number].rjust(8, '0'))
+            company ||= Company.find_by(name: company_params[:name])
+            company ||= Company.new(company_params)
+            if company.new_record?
+              if company.valid?
+                # puts "Would save new company: #{company.name}"
+                company.save
+              else
+                puts "Invalid new company:   #{company.inspect}"
+                puts company.errors.inspect
+              end
+            end
+          elsif company_id.to_i.positive?
+            begin
+              company = Company.find company_id
+              # puts "Would use existing company: #{company.name}"
+            rescue ActiveRecord::RecordNotFound
+              puts "Company not found: #{company_id}"
+              puts statement.inspect
+              next
+            end
+          else
+            puts "*ERROR*:  #{params.inspect}"
           end
-        elsif company_id.positive?
-          begin
-            company = Company.find company_id
-          rescue ActiveRecord::RecordNotFound
-            puts "Company not found: #{company_id}"
-            puts statement.inspect
-            next
-          end
-        else
-          puts "*ERROR*:  #{params.inspect}"
-        end
 
+          if index == 0
+            lead_company = company
+          else
+            additional_companies << company
+          end
+        end
         # create the new Statement:
         # - if it doesn't already exist
         # - also create a `legislation_statements` association
-        company.statements.first_or_create(params) do |new_statement|
+
+        lead_company.statements.build(params) do |new_statement|
+        # Statement.new(params) do |new_statement|
+          # new_statement.company_id = lead_company.id
           if new_statement.valid?
             new_statement.home_office_audit = true
             # ^ set `home_office_audit` to TRUE, as all these imported statements are the result of an audit
+
+            # puts "Would save: new statement for `#{lead_company.name}` in #{new_statement.last_year_covered}"
             new_statement.save
-            # puts "would save: new statement for `#{company.name}` in #{new_statement.last_year_covered}"
+
+            # puts "Would save: new legislation_statements for `#{lead_company.name}` in #{new_statement.last_year_covered}"
             new_statement.legislation_statements.first_or_create(legislation_id: 1).save
             # ^ Given that all the new companies being imported in this audit are in the UK, all new statements shall be linked to the "UK Modern Slavery Act"
+
+            # puts "Would save: new comapnies_statements for `#{additional_companies.length}` additional companies related to #{lead_company.name}"
+            # puts additional_companies.map(&:name).inspect
+            new_statement.additional_companies_covered << additional_companies
+
+            # Update the lead company's `latest_statement_for_compliance_stats`
+            lead_company.update(latest_statement_for_compliance_stats: new_statement)
+
+            count += 1
           else
             puts "Invalid new statement: #{new_statement.company_id}"
             puts new_statement.url
             puts new_statement.errors.messages.inspect
+            invalid += 1
           end
         end
+
       end # of AR Transacton
+      rows += 1
     end # of `statements.each` loop
-    puts 'Finished.'
+
+    puts "Finished."
+    puts "Imported #{count} statements from #{rows} rows."
+    puts "Invalid = #{invalid}." if invalid > 0
   end
 
   def format(value, index)


### PR DESCRIPTION
- statements.csv now has correct `related_companies` data in the last column
- related companies are being explicitly saved with the new statement
- ALL statements are created at every run - this task is no longer idempotent